### PR TITLE
fix typo: Sever -> Server

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -105,7 +105,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		return subcommands.ExitSuccess
 	}
 
-	log.Info("Starting HTTP Sever...")
+	log.Info("Starting HTTP Server...")
 	if err := server.Start(); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure


### PR DESCRIPTION
I found a typo in `commands/server.go` . This pull request fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kotakanbe/go-cve-dictionary/12)
<!-- Reviewable:end -->
