### PR TITLE
Add support for MySQL as a DB storage back-end

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -20,6 +20,7 @@ type FetchJvnCmd struct {
 	debugSQL bool
 
 	dbpath   string
+	dbtype   string
 	dumpPath string
 
 	latest bool
@@ -42,7 +43,8 @@ func (*FetchJvnCmd) Usage() string {
 		[-latest]
 		[-last2y]
 		[-years] 1998 1999 ...
-		[-dbpath=$PWD/cve.sqlite3]
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
+		[-dbtype=mysql|sqlite3]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
@@ -58,7 +60,9 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 		"SQL debug mode")
 
 	pwd := os.Getenv("PWD")
-	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3", "/path/to/sqlite3")
+	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3", "/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&p.dbtype, "dbtype", "sqlite3", "Database type to store data in (sqlite3 or mysql supported)")
 
 	f.BoolVar(&p.latest, "latest", false,
 		"Refresh JVN data for latest.")
@@ -88,6 +92,7 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	c.Conf.DBPath = p.dbpath
+	c.Conf.DBType = p.dbtype
 	//  c.Conf.DumpPath = p.dumpPath
 	c.Conf.HTTPProxy = p.httpProxy
 
@@ -139,7 +144,7 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 	log.Infof("Fetched %d CVEs", len(items))
 
-	log.Infof("Opening DB. datafile: %s", c.Conf.DBPath)
+	log.Infof("Opening DB (%s).", c.Conf.DBType)
 	if err := db.OpenDB(); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -20,6 +20,7 @@ type FetchNvdCmd struct {
 	debugSQL bool
 
 	dbpath string
+	dbtype string
 
 	last2Y bool
 	years  bool
@@ -39,7 +40,8 @@ func (*FetchNvdCmd) Usage() string {
 	fetchnvd
 		[-last2y]
 		[-years] 2015 2016 ...
-		[-dbpath=/path/to/cve.sqlite3]
+		[-dbtype=mysql|sqlite3]
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
@@ -58,7 +60,9 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"SQL debug mode")
 
 	pwd := os.Getenv("PWD")
-	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3", "/path/to/sqlite3")
+	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3", "/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&p.dbtype, "dbtype", "sqlite3", "Database type to store data in (sqlite3 or mysql supported)")
 
 	f.BoolVar(&p.last2Y, "last2y", false,
 		"Refresh NVD data in the last two years.")
@@ -85,6 +89,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	c.Conf.DBPath = p.dbpath
+	c.Conf.DBType = p.dbtype
 	c.Conf.HTTPProxy = p.httpProxy
 
 	if !c.Conf.Validate() {
@@ -133,7 +138,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 	log.Infof("Fetched %d CVEs", len(entries))
 
-	log.Infof("Opening DB. datafile: %s", c.Conf.DBPath)
+	log.Infof("Opening DB (%s).", c.Conf.DBType)
 	if err := db.OpenDB(); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure

--- a/commands/server.go
+++ b/commands/server.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/google/subcommands"
@@ -19,6 +18,7 @@ type ServerCmd struct {
 	debugSQL bool
 
 	dbpath string
+	dbtype string
 	bind   string
 	port   string
 }
@@ -35,7 +35,8 @@ func (*ServerCmd) Usage() string {
 	server
 		[-bind=127.0.0.1]
 		[-port=8000]
-		[-dbpath=$PWD/cve.sqlite3]
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
+		[-dbtype=mysql|sqlite3]
 		[-debug]
 		[-debug-sql]
 
@@ -50,8 +51,9 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 		"SQL debug mode (default: false)")
 
 	pwd := os.Getenv("PWD")
-	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
-		fmt.Sprintf("/path/to/sqlite3"))
+	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3", "/path/to/sqlite3 or SQL connection string")
+
+	f.StringVar(&p.dbtype, "dbtype", "sqlite3", "Database type to store data in (sqlite3 or mysql supported)")
 
 	f.StringVar(&p.bind,
 		"bind",
@@ -74,12 +76,13 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.Bind = p.bind
 	c.Conf.Port = p.port
 	c.Conf.DBPath = p.dbpath
+    c.Conf.DBType = p.dbtype
 
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError
 	}
 
-	log.Infof("Opening DB. datafile: %s", c.Conf.DBPath)
+	log.Infof("Opening DB (%s).", c.Conf.DBType)
 	if err := db.OpenDB(); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 
 	DumpPath string
 	DBPath   string
+	DBType   string
 
 	FetchJvnWeek       bool
 	FetchJvnMonth      bool
@@ -30,9 +31,11 @@ type Config struct {
 
 // Validate validates configuration
 func (c *Config) Validate() bool {
-	if ok, _ := valid.IsFilePath(c.DBPath); !ok {
-		log.Errorf("SQLite3 DB path must be a *Absolute* file path. dbpath: %s", c.DBPath)
-		return false
+	if c.DBType == "sqlite3" {
+		if ok, _ := valid.IsFilePath(c.DBPath); !ok {
+			log.Errorf("SQLite3 DB path must be a *Absolute* file path. dbpath: %s", c.DBPath)
+			return false
+		}
 	}
 
 	if len(c.DumpPath) != 0 {

--- a/db/db.go
+++ b/db/db.go
@@ -15,27 +15,47 @@ import (
 	jvn "github.com/kotakanbe/go-cve-dictionary/jvn"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/nvd"
+
+	// Required MySQL.  See http://jinzhu.me/gorm/database.html#connecting-to-a-database
+	_ "github.com/jinzhu/gorm/dialects/mysql"
 )
 
 var db *gorm.DB
 
+// Supported DB dialects.
+const (
+	dialectSqlite3 = "sqlite3"
+	dialectMysql   = "mysql"
+)
+
 // OpenDB opens Database
 func OpenDB() (err error) {
-	db, err = gorm.Open("sqlite3", c.Conf.DBPath)
-	if err != nil {
-		err = fmt.Errorf("Failed to open DB. datafile: %s, err: %s", c.Conf.DBPath, err)
-		return
 
+	db, err = gorm.Open(c.Conf.DBType, c.Conf.DBPath)
+	if err != nil {
+		if c.Conf.DBType == dialectSqlite3 {
+			err = fmt.Errorf("Failed to open DB. datafile: %s, err: %s", c.Conf.DBPath, err)
+		} else if c.Conf.DBType == dialectMysql {
+			err = fmt.Errorf("Failed to open DB, err: %s", err)
+		} else {
+			err = fmt.Errorf("Invalid database dialect, %s.", c.Conf.DBType)
+		}
+		return
 	}
+
 	db.LogMode(c.Conf.DebugSQL)
-	db.Exec("PRAGMA journal_mode=WAL;")
+
+	if c.Conf.DBType == dialectSqlite3 {
+		db.Exec("PRAGMA journal_mode=WAL;")
+	}
+
 	return
 }
 
 func recconectDB() error {
 	var err error
 	if err = db.Close(); err != nil {
-		return fmt.Errorf("Failed to close DB. datafile: %s, err: %s", c.Conf.DBPath, err)
+		return fmt.Errorf("Failed to close DB. Type: %s, Path: %s, err: %s", c.Conf.DBType, c.Conf.DBPath, err)
 	}
 	return OpenDB()
 }
@@ -127,6 +147,7 @@ func Get(cveID string, priorityDB ...*gorm.DB) models.CveDetail {
 	conn.Model(&c).Related(&nvd, "Nvd")
 	c.Nvd = nvd
 
+	fmt.Printf("nvd: %v\n", nvd)
 	if nvd.CveDetailID != 0 && nvd.ID != 0 {
 		nvdRefs := []models.Reference{}
 		conn.Model(&nvd).Related(&nvdRefs, "References")
@@ -138,6 +159,7 @@ func Get(cveID string, priorityDB ...*gorm.DB) models.CveDetail {
 		//  c.Nvd.Cpes = nvdCpes
 	}
 
+	fmt.Printf("C: %v\n", c)
 	return c
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -98,7 +98,8 @@ type Nvd struct {
 	gorm.Model  `json:"-"`
 	CveDetailID uint `json:"-"`
 
-	Summary string
+	// Increased size of summary to ensure we can fit arbitrary CVE content.
+	Summary               string `gorm:"size:4096"`
 
 	Score                 float64 // 1 to 10
 	AccessVector          string
@@ -214,7 +215,7 @@ type Jvn struct {
 	CveDetailID uint `json:"-"`
 
 	Title   string
-	Summary string
+	Summary string    `gorm:"size:8192"`
 	JvnLink string
 	JvnID   string
 
@@ -325,5 +326,5 @@ type Reference struct {
 	NvdID      uint `json:"-"`
 
 	Source string
-	Link   string
+	Link   string   `gorm:"size:512"`
 }


### PR DESCRIPTION
Added support to use MySQL as the back-end storage.  I have tested pulling CVE's and running a server to ensure that I can successfully store and read in data.

`./go-cve-dictionary fetchnvd -years -dbtype mysql -dbpath root:oswell@/vuls?parseTime=true 2016`
`./go-cve-dictionary server -dbtype mysql -dbpath root:oswell@/vuls?parseTime=true`

I opted to overload the "dbpath" flag for the MySQL connection string as the naming still sort of makes sense and it required less changes.
