### PR TITLE
Remove vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ lint:
 	$(foreach file,$(SRCS),golint $(file) || exit;)
 
 vet:
-	@-go get -v golang.org/x/tools/cmd/vet
 	$(foreach pkg,$(PKGS),go vet $(pkg);)
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 	clean
 
 SRCS = $(shell git ls-files '*.go')
-PKGS =  ./commands ./config ./db ./jvn ./log ./models ./nvd ./server ./cache
+PKGS =  ./commands ./config ./db ./jvn ./log ./models ./nvd ./server
 VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 LDFLAGS := -X 'main.version=$(VERSION)' \


### PR DESCRIPTION
go 1.6 has vet included.

- https://github.com/purpleidea/mgmt/pull/38
- http://stackoverflow.com/questions/37755531/cannot-install-vet-package-with-go-get

> go v1.7.1 or later
>> https://github.com/kotakanbe/go-cve-dictionary

go version is no problem.