### PR TITLE
Moved golang.org/x/net/context to context

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	db "github.com/kotakanbe/go-cve-dictionary/db"
 	"github.com/kotakanbe/go-cve-dictionary/jvn"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
-	"golang.org/x/net/context"
 )
 
 // FetchJvnCmd is Subcommand for fetch JVN information.

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strconv"
@@ -11,7 +12,6 @@ import (
 	db "github.com/kotakanbe/go-cve-dictionary/db"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/nvd"
-	"golang.org/x/net/context"
 )
 
 // FetchNvdCmd is Subcommand for fetch Nvd information.

--- a/commands/server.go
+++ b/commands/server.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/db"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	server "github.com/kotakanbe/go-cve-dictionary/server"
-	"golang.org/x/net/context"
 )
 
 // ServerCmd is Subcommand for CVE dictionary HTTP Server
@@ -76,7 +76,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.Bind = p.bind
 	c.Conf.Port = p.port
 	c.Conf.DBPath = p.dbpath
-    c.Conf.DBType = p.dbtype
+	c.Conf.DBType = p.dbtype
 
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError

--- a/glide.lock
+++ b/glide.lock
@@ -12,7 +12,7 @@ imports:
 - name: github.com/go-sql-driver/mysql
   version: 2a6c6079c7eff49a7e9d641e109d922f124a3e4c
 - name: github.com/google/subcommands
-  version: 1c7173745a6001f67d8d96ab4e178284c77f7759
+  version: a71b91e238406bd68766ee52db63bebedce0e9f6
 - name: github.com/jinzhu/gorm
   version: 39165d498058a823126af3cbf4d2a3b0e1acf11e
   subpackages:

--- a/main.go
+++ b/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
-
-	"golang.org/x/net/context"
 
 	"github.com/google/subcommands"
 	"github.com/kotakanbe/go-cve-dictionary/commands"


### PR DESCRIPTION
Corresponding to https://github.com/google/subcommands/pull/5.

- https://tip.golang.org/doc/go1.7#context

Currently, `go get github.com/kotakanbe/go-cve-dictionary` is failed. It's ok according to a latest README, but an old README is still referred, so I fixed it.

- https://github.com/kotakanbe/go-cve-dictionary/commit/683256b65f7f968df15a99f08054c08e4b597490#diff-04c6e90faac2675aa89e2176d2eec7d8L52
- http://dev.classmethod.jp/etc/vuls-security-install/
- https://blog.animereview.jp/vuls/
- http://qiita.com/sadayuki-matsuno/items/0bb8bb1689425bb9a21c