### PR TITLE
Simplify fetch examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Fetch Vulnerability data from NVD.
 It takes about 10 minutes (on AWS).  
 
 ```bash
-$ for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i; done
+$ go-cve-dictionary fetchnvd -years {2002..2016}
 ... snip ...
 $ ls -alh cve.sqlite3
 -rw-r--r-- 1 ec2-user ec2-user 7.0M Mar 24 13:20 cve.sqlite3
@@ -224,7 +224,7 @@ fetchnvd:
                 [-debug-sql]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
-   $ for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i ; done
+   $ go-cve-dictionary fetchnvd -years {2002..2016}
 
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
@@ -256,7 +256,7 @@ $ go-cve-dictionary fetchnvd -years 2002 2003 2016
 
 - Fetch NVD data for entire period.
 ```
-for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i; done
+go-cve-dictionary fetchnvd -years {2002..2016}
 
 ```
 
@@ -301,7 +301,7 @@ fetchjvn:
 - Fetch data for entire period
 
 ```
-for i in {1998..2016}; do go-cve-dictionary fetchjvn -years $i; done
+go-cve-dictionary fetchjvn -years {1998..2016}
 ```
 
 - Fetch data in the last two years

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -47,7 +47,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-debug-sql]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
-   $ for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i; done
+   $ go-cve-dictionary fetchnvd -years {2002..2016}
 
 `
 }

--- a/commands/server.go
+++ b/commands/server.go
@@ -103,7 +103,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	if count == 0 {
 		log.Info("No Vulnerability data found. Run the below command to fetch data from NVD")
 		log.Info("")
-		log.Info(" for i in {2002..2016}; do go-cve-dictionary fetchnvd -years $i ; done")
+		log.Info(" go-cve-dictionary fetchnvd -years {2002..2016}")
 		log.Info("")
 		return subcommands.ExitSuccess
 	}


### PR DESCRIPTION
This is arguably simpler, faster, produces better logging, and better reflects the options of the fetch commands.

A future-proof way would be to do something like `$(seq 2002 $(date +%Y))` rather than `{2002..2016}`