### PR TITLE
Remove CR(^M) in JVN (Vulnerability database in Japanese)

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -38,7 +38,7 @@ func OpenDB() (err error) {
 		} else if c.Conf.DBType == dialectMysql {
 			err = fmt.Errorf("Failed to open DB, err: %s", err)
 		} else {
-			err = fmt.Errorf("Invalid database dialect, %s.", c.Conf.DBType)
+			err = fmt.Errorf("Invalid database dialect, %s", c.Conf.DBType)
 		}
 		return
 	}
@@ -301,16 +301,12 @@ func errDelete(c models.CveDetail, err error) error {
 // ConvertJvn converts Jvn structure(got from JVN) to model structure.
 func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 	for _, item := range items {
-		//TODO
-		//  pp.Println(item.Cvss.Score)
-
 		if item.Cvss.Score == "0" || len(item.Cvss.Score) == 0 {
 			log.Debugf("Skip. CVSS Score is zero. JvnID: %s", item.Identifier)
 			//ignore invalid item
 			continue
 		}
 
-		// TODO commentout because db size will be big. so Uncomment if needed.
 		//  References
 		refs := []models.Reference{}
 		for _, r := range item.References {
@@ -321,7 +317,6 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 			refs = append(refs, ref)
 		}
 
-		// TODO commentout because db size will be big. so Uncomment if needed.
 		// Cpes
 		cpes := []models.Cpe{}
 		for _, c := range item.CpeItem {
@@ -363,8 +358,8 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 
 			// JVN
 			Jvn: models.Jvn{
-				Title:   item.Title,
-				Summary: item.Description,
+				Title:   strings.Replace(item.Title, "\r", "", -1),
+				Summary: strings.Replace(item.Description, "\r", "", -1),
 				JvnLink: item.Link,
 				JvnID:   item.Identifier,
 
@@ -373,7 +368,6 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 				Vector:   item.Cvss.Vector,
 				//  Version:  item.Cvss.Version,
 
-				// TODO commentout because db size will be big. so Uncomment if needed.
 				References: refs,
 				Cpes:       cpes,
 
@@ -470,7 +464,6 @@ func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
 		//      continue
 		//  }
 
-		// TODO commentout because db size will be big. so Uncomment if needed.
 		// References
 		refs := []models.Reference{}
 		for _, r := range entry.References {
@@ -481,7 +474,6 @@ func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
 			refs = append(refs, ref)
 		}
 
-		// TODO commentout because db size will be big. so Uncomment if needed.
 		//  // Cpes
 		cpes := []models.Cpe{}
 		for _, c := range entry.Products {
@@ -507,7 +499,6 @@ func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
 				PublishedDate:         entry.PublishedDate,
 				LastModifiedDate:      entry.LastModifiedDate,
 
-				// TODO commentout because db size will be big. so Uncomment if needed.
 				Cpes:       cpes,
 				References: refs,
 			},

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,8 @@
-hash: d7dee93a0ceebf68765d29536d10a8d503df3b54b4e2c0deb04954fc6d846a1f
-updated: 2016-10-31T13:34:58.846115939+09:00
+hash: b91d08c61acf169a1bf577b6a9b593ec16cb3fc70666f926203990e1b15ddec4
+updated: 2016-11-29T23:20:22.419200881+09:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
-- name: github.com/cenkalti/backoff
-  version: 8edc80b07f38c27352fb186d971c628a6c32552b
 - name: github.com/cheggaaa/pb
   version: ad4efe000aa550bb54918c06ebbadc0ff17687b9
 - name: github.com/dgrijalva/jwt-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,10 +2,11 @@ package: github.com/kotakanbe/go-cve-dictionary
 import:
 - package: github.com/Sirupsen/logrus
 - package: github.com/asaskevich/govalidator
-- package: github.com/cenkalti/backoff
 - package: github.com/cheggaaa/pb
 - package: github.com/google/subcommands
 - package: github.com/jinzhu/gorm
+  subpackages:
+  - dialects/mysql
 - package: github.com/k0kubun/pp
 - package: github.com/kotakanbe/logrus-prefixed-formatter
 - package: github.com/labstack/echo
@@ -15,6 +16,3 @@ import:
 - package: github.com/mattn/go-sqlite3
 - package: github.com/parnurzeal/gorequest
 - package: github.com/rifflock/lfshook
-- package: golang.org/x/net
-  subpackages:
-  - context


### PR DESCRIPTION
CRLF is used as a line feed code in titles, summaries in JVN which is a Japanese vulnerability database.
As it is, it will collapse at terminal display, so remove CR when inserting to DB.