### PR TITLE
Fix package import

### DIFF
--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/future-architect/vuls/util"
+	"github.com/kotakanbe/go-cve-dictionary/util"
 	"github.com/google/subcommands"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	db "github.com/kotakanbe/go-cve-dictionary/db"

--- a/commands/server.go
+++ b/commands/server.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"os"
 
-	"github.com/future-architect/vuls/util"
+	"github.com/kotakanbe/go-cve-dictionary/util"
 	"github.com/google/subcommands"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/db"


### PR DESCRIPTION
Fix import error

```
go build -ldflags "-X 'main.version=v0.1.0' -X 'main.revision=1551cb5'" -o go-cve-dictionary main.go
commands/fetchnvd.go:10:2: cannot find package "github.com/future-architect/vuls/util" in any of:
        /go/vuls/src/github.com/kotakanbe/go-cve-dictionary/vendor/github.com/future-architect/vuls/util (vendor tree)
        /usr/local/Cellar/go/1.7.4_2/libexec/src/github.com/future-architect/vuls/util (from $GOROOT)
        /go/vuls/src/github.com/future-architect/vuls/util (from $GOPATH)
make: *** [build] Error 1
```