### PR TITLE
add redis as db back end

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,12 @@
   version = "v3.0.0"
 
 [[projects]]
+  name = "github.com/go-redis/redis"
+  packages = [".","internal","internal/consistenthash","internal/hashtag","internal/pool","internal/proto"]
+  revision = "663bb76bcc3763c41877b63671003705a47289c5"
+  version = "v6.4.1"
+
+[[projects]]
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   revision = "a0583e0143b1624142adab07e0e97fe106d99561"
@@ -166,6 +172,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1012bbec498fae258526bc47e36e4fa5847d4bae5bd04d310d5b6ec0dddc4b76"
+  inputs-digest = "66f23fe639c35f33e23f9b48ffd1489aa8f41fc511b47124103b1afa81379067"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ copy is generated in sqlite format, and the tool has a server mode for easy quer
 
 go-cve-dictionary requires the following packages.
 
-- SQLite3 or MySQL
+- SQLite3, MySQL, Postgres or Redis
 - git
 - gcc
 - go v1.7.1 or later
@@ -216,7 +216,7 @@ fetchnvd:
         fetchnvd
                 [-last2y]
                 [-years] 2015 2016 ...
-                [-dbtype=mysql|postgres|sqlite3]
+                [-dbtype=mysql|postgres|sqlite3|redis]
                 [-dbpath=$PWD/cve.sqlite3 or connection string]
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
@@ -229,7 +229,7 @@ For the first time, run the blow command to fetch data for entire period. (It ta
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
   -dbtype string
-        Database type to store data in (sqlite3, mysql or postgres supported) (default "sqlite3")
+        Database type to store data in (sqlite3, mysql ,postgres or redis supported) (default "sqlite3")
   -debug
         debug mode
   -debug-sql
@@ -276,7 +276,7 @@ fetchjvn:
                 [-years] 1998 1999 ...
                 [-dbpath=$PWD/cve.sqlite3]
                 [-dbpath=$PWD/cve.sqlite3 or connection string]
-                [-dbtype=mysql|postgres|sqlite3]
+                [-dbtype=mysql|postgres|sqlite3|redis]
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
@@ -285,7 +285,7 @@ fetchjvn:
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
   -dbtype string
-        Database type to store data in (sqlite3, mysql or postgres supported) (default "sqlite3")
+        Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
   -debug
         debug mode
   -debug-sql
@@ -332,7 +332,7 @@ server:
                 [-bind=127.0.0.1]
                 [-port=8000]
                 [-dbpath=$PWD/cve.sqlite3 or connection string]
-                [-dbtype=mysql|postgres|sqlite3]
+                [-dbtype=mysql|postgres|sqlite3|redis]
                 [-debug]
                 [-debug-sql]
                 [-log-dir]
@@ -342,7 +342,7 @@ server:
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default : $PWD/cve.sqlite3)
   -dbtype string
-        Database type to store data in (sqlite3, mysql or postgres supported) (default "sqlite3")
+        Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
   -debug
         debug mode (default: false)
   -debug-sql
@@ -402,12 +402,35 @@ $ go-cve-dictionary server \
       -dbpath "host=myhost user=user dbname=dbname sslmode=disable password=password" 
 ```
 
+# Usage: Use Redis as a DB storage back-end
+
+- fetchnvd
+```
+$ go-cve-dictionary fetchnvd -last2y \
+      -dbtype redis \
+      -dbpath "redis://localhost/0"
+```
+
+- fetchjvn
+```
+$ go-cve-dictionary fetchjvn -last2y \
+      -dbtype redis \
+      -dbpath "redis://localhost/0"
+```
+
+- server
+```
+$ go-cve-dictionary server \
+      -dbtype redis \
+      -dbpath "redis://localhost/0"
+```
+
 ----
 
 # How to Update
 
 - Update go-cve-dictionary  
-If the DB schema was changed, please specify new SQLite3 or MySQL DB file.
+If the DB schema was changed, please specify new SQLite3, MySQL, Postgres or Redis DB file.
 
 ```
 $ cd $GOPATH/src/github.com/kotakanbe/go-cve-dictionary

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -46,7 +46,7 @@ func (*FetchJvnCmd) Usage() string {
 		[-last2y]
 		[-years] 1998 1999 ...
 		[-dbpath=$PWD/cve.sqlite3 or connection string]
-		[-dbtype=mysql|postgres|sqlite3]
+		[-dbtype=mysql|postgres|sqlite3|redis]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
@@ -70,7 +70,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 		"/path/to/sqlite3 or SQL connection string")
 
 	f.StringVar(&p.dbtype, "dbtype", "sqlite3",
-		"Database type to store data in (sqlite3,  mysql or postgres supported)")
+		"Database type to store data in (sqlite3,  mysql, postgres or redis supported)")
 
 	f.BoolVar(&p.latest, "latest", false,
 		"Refresh JVN data for latest.")
@@ -152,19 +152,26 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 	log.Infof("Fetched %d CVEs", len(items))
 
-	log.Infof("Opening DB (%s).", c.Conf.DBType)
-	if err := db.OpenDB(); err != nil {
+	var driver db.DB
+	if driver, err = db.NewDB(c.Conf.DBType); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	log.Info("Migrating DB")
-	if err := db.MigrateDB(); err != nil {
+	log.Infof("Opening DB (%s).", driver.Name())
+	if err := driver.OpenDB(c.Conf.DBType, c.Conf.DBPath, c.Conf.DebugSQL); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	if err := db.InsertJvn(items); err != nil {
+	log.Infof("Migrating DB (%s).", driver.Name())
+	if err := driver.MigrateDB(); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+
+	log.Infof("Inserting JVN into DB (%s).", driver.Name())
+	if err := driver.InsertJvn(items); err != nil {
 		log.Fatalf("Failed to inert. dbpath: %s, err: %s", c.Conf.DBPath, err)
 		return subcommands.ExitFailure
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -42,7 +42,7 @@ func (*FetchNvdCmd) Usage() string {
 	fetchnvd
 		[-last2y]
 		[-years] 2015 2016 ...
-		[-dbtype=mysql|postgres|sqlite3]
+		[-dbtype=mysql|postgres|sqlite3|redis]
 		[-dbpath=$PWD/cve.sqlite3 or connection string]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
@@ -70,7 +70,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"/path/to/sqlite3 or SQL connection string")
 
 	f.StringVar(&p.dbtype, "dbtype", "sqlite3",
-		"Database type to store data in (sqlite3, mysql or postgres supported)")
+		"Database type to store data in (sqlite3, mysql, postgres or redis supported)")
 
 	f.BoolVar(&p.last2Y, "last2y", false,
 		"Refresh NVD data in the last two years.")
@@ -146,19 +146,26 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 	log.Infof("Fetched %d CVEs", len(entries))
 
-	log.Infof("Opening DB (%s).", c.Conf.DBType)
-	if err := db.OpenDB(); err != nil {
+	var driver db.DB
+	if driver, err = db.NewDB(c.Conf.DBType); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	log.Info("Migrating DB")
-	if err := db.MigrateDB(); err != nil {
+	log.Infof("Opening DB (%s).", driver.Name())
+	if err := driver.OpenDB(c.Conf.DBType, c.Conf.DBPath, c.Conf.DebugSQL); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	if err := db.InsertNvd(entries); err != nil {
+	log.Infof("Migrating DB (%s).", driver.Name())
+	if err := driver.MigrateDB(); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+
+	log.Infof("Inserting NVD into DB (%s).", driver.Name())
+	if err := driver.InsertNvd(entries); err != nil {
 		log.Errorf("Failed to inert. dbpath: %s, err: %s",
 			c.Conf.DBPath, err)
 		return subcommands.ExitFailure

--- a/commands/server.go
+++ b/commands/server.go
@@ -38,7 +38,7 @@ func (*ServerCmd) Usage() string {
 		[-bind=127.0.0.1]
 		[-port=8000]
 		[-dbpath=$PWD/cve.sqlite3 or connection string]
-		[-dbtype=mysql|postgres|sqlite3]
+		[-dbtype=mysql|postgres|sqlite3|redis]
 		[-debug]
 		[-debug-sql]
 		[-log-dir=/path/to/log]
@@ -61,7 +61,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 		"/path/to/sqlite3 or SQL connection string")
 
 	f.StringVar(&p.dbtype, "dbtype", "sqlite3",
-		"Database type to store data in (sqlite3, mysql or postgres supported)")
+		"Database type to store data in (sqlite3, mysql, postgres or redis supported)")
 
 	f.StringVar(&p.bind,
 		"bind",
@@ -90,20 +90,27 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		return subcommands.ExitUsageError
 	}
 
-	log.Infof("Opening DB (%s).", c.Conf.DBType)
-	if err := db.OpenDB(); err != nil {
+	var driver db.DB
+	var err error
+	if driver, err = db.NewDB(c.Conf.DBType); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	log.Info("Migrating DB")
-	if err := db.MigrateDB(); err != nil {
+	log.Infof("Opening DB (%s).", driver.Name())
+	if err := driver.OpenDB(c.Conf.DBType, c.Conf.DBPath, c.Conf.DebugSQL); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}
 
-	count, err := db.CountNvd()
-	if err != nil {
+	log.Infof("Migrating DB (%s).", driver.Name())
+	if err = driver.MigrateDB(); err != nil {
+		log.Error(err)
+		return subcommands.ExitFailure
+	}
+
+	var count int
+	if count, err = driver.CountNvd(); err != nil {
 		log.Errorf("Failed to count NVD table: %s", err)
 		return subcommands.ExitFailure
 	}
@@ -117,7 +124,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	log.Info("Starting HTTP Server...")
-	if err := server.Start(p.logDir); err != nil {
+	if err = server.Start(p.logDir, driver); err != nil {
 		log.Error(err)
 		return subcommands.ExitFailure
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -6,16 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cheggaaa/pb"
-	log "github.com/kotakanbe/go-cve-dictionary/log"
-
-	"github.com/jinzhu/gorm"
-	"github.com/k0kubun/pp"
-	c "github.com/kotakanbe/go-cve-dictionary/config"
 	jvn "github.com/kotakanbe/go-cve-dictionary/jvn"
+	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/nvd"
-
 	// Required MySQL.  See http://jinzhu.me/gorm/database.html#connecting-to-a-database
 	_ "github.com/jinzhu/gorm/dialects/mysql"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -23,298 +17,88 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
-var db *gorm.DB
-
 // Supported DB dialects.
 const (
 	dialectSqlite3    = "sqlite3"
 	dialectMysql      = "mysql"
 	dialectPostgreSQL = "postgres"
+	dialectRedis      = "redis"
 )
 
-// OpenDB opens Database
-func OpenDB() (err error) {
+// DB is interface for a database driver
+type DB interface {
+	Name() string
+	OpenDB(string, string, bool) error
+	MigrateDB() error
+	Get(string) *models.CveDetail
+	GetByCpeName(string) []*models.CveDetail
+	InsertJvn([]jvn.Item) error
+	InsertNvd([]nvd.Entry) error
+	CountNvd() (int, error)
+}
 
-	db, err = gorm.Open(c.Conf.DBType, c.Conf.DBPath)
-	if err != nil {
-		if c.Conf.DBType == dialectSqlite3 {
-			err = fmt.Errorf("Failed to open DB. datafile: %s, err: %s", c.Conf.DBPath, err)
-		} else if c.Conf.DBType == dialectMysql || c.Conf.DBType == dialectPostgreSQL {
-			err = fmt.Errorf("Failed to open DB, err: %s", err)
-		} else {
-			err = fmt.Errorf("Invalid database dialect, %s", c.Conf.DBType)
+// NewDB return DB accessor.
+func NewDB(dbType string) (DB, error) {
+	switch dbType {
+	case dialectSqlite3, dialectMysql, dialectPostgreSQL:
+		return &RDBDriver{name: dbType}, nil
+	case dialectRedis:
+		return &RedisDriver{name: dbType}, nil
+	}
+	return nil, fmt.Errorf("Invalid database dialect, %s", dbType)
+}
+
+// convertNvd converts Nvd structure(got from NVD) to model structure.
+func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
+	for _, entry := range entries {
+		//  if entry.Cvss.Score == "0" || len(entry.Cvss.Score) == 0 {
+		//      log.Warnf("Skip. CVSS Score is zero. JvnID: %s", entry.CveID)
+		//      //ignore invalid item
+		//      continue
+		//  }
+
+		// References
+		refs := []models.Reference{}
+		for _, r := range entry.References {
+			ref := models.Reference{
+				Source: r.Source,
+				Link:   r.Link.Href,
+			}
+			refs = append(refs, ref)
 		}
-		return
-	}
 
-	db.LogMode(c.Conf.DebugSQL)
+		//  // Cpes
+		cpes := []models.Cpe{}
+		for _, c := range entry.Products {
+			cpe, err := parseCpe(c)
+			if err != nil {
+				panic(err)
+			}
+			cpes = append(cpes, cpe)
+		}
 
-	if c.Conf.DBType == dialectSqlite3 {
-		db.Exec("PRAGMA journal_mode=WAL;")
-	}
-
-	return
-}
-
-func recconectDB() error {
-	var err error
-	if err = db.Close(); err != nil {
-		return fmt.Errorf("Failed to close DB. Type: %s, Path: %s, err: %s", c.Conf.DBType, c.Conf.DBPath, err)
-	}
-	return OpenDB()
-}
-
-// MigrateDB migrates Database
-func MigrateDB() error {
-	if err := db.AutoMigrate(
-		&models.CveDetail{},
-		&models.Jvn{},
-		&models.Nvd{},
-		&models.Reference{},
-		&models.Cpe{},
-	).Error; err != nil {
-		return fmt.Errorf("Failed to migrate. err: %s", err)
-	}
-
-	errMsg := "Failed to create index. err: %s"
-	if err := db.Model(&models.CveDetail{}).
-		AddIndex("idx_cve_detail_cveid", "cve_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Nvd{}).
-		AddIndex("idx_nvds_cve_detail_id", "cve_detail_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Jvn{}).
-		AddIndex("idx_jvns_cve_detail_id", "cve_detail_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Cpe{}).
-		AddIndex("idx_cpes_jvn_id", "jvn_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Reference{}).
-		AddIndex("idx_references_jvn_id", "jvn_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Cpe{}).
-		AddIndex("idx_cpes_nvd_id", "nvd_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Cpe{}).
-		AddIndex("idx_cpes_cpe_name", "cpe_name").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-	if err := db.Model(&models.Reference{}).
-		AddIndex("idx_references_nvd_id", "nvd_id").Error; err != nil {
-		return fmt.Errorf(errMsg, err)
-	}
-
-	return nil
-}
-
-// Get Select Cve information from DB.
-func Get(cveID string, priorityDB ...*gorm.DB) models.CveDetail {
-	var conn *gorm.DB
-	if len(priorityDB) == 1 {
-		conn = priorityDB[0]
-	} else {
-		conn = db
-	}
-
-	c := models.CveDetail{}
-	conn.Where(&models.CveDetail{CveID: cveID}).First(&c)
-
-	if c.ID == 0 {
-		// Avoid null slice being null in JSON
-		return models.CveDetail{
+		cve := models.CveDetail{
+			CveID: entry.CveID,
 			Nvd: models.Nvd{
-				References: []models.Reference{},
-				Cpes:       []models.Cpe{},
+				Summary:               entry.Summary,
+				Score:                 stringToFloat(entry.Cvss.Score),
+				AccessVector:          entry.Cvss.AccessVector,
+				AccessComplexity:      entry.Cvss.AccessComplexity,
+				Authentication:        entry.Cvss.Authentication,
+				ConfidentialityImpact: entry.Cvss.ConfidentialityImpact,
+				IntegrityImpact:       entry.Cvss.IntegrityImpact,
+				AvailabilityImpact:    entry.Cvss.AvailabilityImpact,
+				CweID:                 entry.Cwe.ID,
+				PublishedDate:         entry.PublishedDate,
+				LastModifiedDate:      entry.LastModifiedDate,
+
+				Cpes:       cpes,
+				References: refs,
 			},
-			Jvn: models.Jvn{
-				References: []models.Reference{},
-				Cpes:       []models.Cpe{},
-			},
 		}
-	}
-
-	// JVN
-	jvn := models.Jvn{}
-	conn.Model(&c).Related(&jvn, "Jvn")
-	c.Jvn = jvn
-
-	if jvn.CveDetailID != 0 && jvn.ID != 0 {
-		jvnRefs := []models.Reference{}
-		conn.Model(&jvn).Related(&jvnRefs, "References")
-		c.Jvn.References = jvnRefs
-
-		// TODO commentout because JSON response size will be big. so Uncomment if needed.
-		//  jvnCpes := []models.Cpe{}
-		//  conn.Model(&jvn).Related(&jvnCpes, "Cpes")
-		//  c.Jvn.Cpes = jvnCpes
-		if c.Jvn.Cpes == nil {
-			c.Jvn.Cpes = []models.Cpe{}
-		}
-	}
-
-	// NVD
-	nvd := models.Nvd{}
-	conn.Model(&c).Related(&nvd, "Nvd")
-	c.Nvd = nvd
-
-	if nvd.CveDetailID != 0 && nvd.ID != 0 {
-		nvdRefs := []models.Reference{}
-		conn.Model(&nvd).Related(&nvdRefs, "References")
-		c.Nvd.References = nvdRefs
-
-		// TODO commentout because JSON response size will be big. so Uncomment if needed.
-		//  nvdCpes := []models.Cpe{}
-		//  conn.Model(&nvd).Related(&nvdCpes, "Cpes")
-		//  c.Nvd.Cpes = nvdCpes
-		if c.Nvd.Cpes == nil {
-			c.Nvd.Cpes = []models.Cpe{}
-		}
-	}
-
-	return c
-}
-
-// GetByCpeName Select Cve information from DB.
-func GetByCpeName(cpeName string) (details []models.CveDetail) {
-	cpes := []models.Cpe{}
-	db.Where(&models.Cpe{CpeName: cpeName}).Find(&cpes)
-
-	for _, cpe := range cpes {
-		var cveDetailID uint
-		if cpe.JvnID != 0 {
-			//TODO test check CPE name format of JVN table
-			jvn := models.Jvn{}
-			db.Select("cve_detail_id").Where("ID = ?", cpe.JvnID).First(&jvn)
-			cveDetailID = jvn.CveDetailID
-		} else if cpe.NvdID != 0 {
-			nvd := models.Nvd{}
-			db.Select("cve_detail_id").Where("ID = ?", cpe.NvdID).First(&nvd)
-			cveDetailID = nvd.CveDetailID
-		}
-
-		cveDetail := models.CveDetail{}
-		db.Select("cve_id").Where("ID = ?", cveDetailID).First(&cveDetail)
-		cveID := cveDetail.CveID
-		details = append(details, Get(cveID))
+		cves = append(cves, cve)
 	}
 	return
-}
-
-// InsertJvn insert items fetched from JVN.
-func InsertJvn(items []jvn.Item) error {
-	log.Info("Inserting fetched CVEs...")
-
-	cves := convertJvn(items)
-	if err := insertIntoJvn(cves); err != nil {
-		return err
-	}
-	return nil
-}
-
-// InsertIntoJvn inserts Cve Information into DB
-func insertIntoJvn(cves []models.CveDetail) error {
-	var refreshedJvns []string
-	bar := pb.StartNew(len(cves))
-
-	for chunked := range chunkSlice(cves, 10) {
-		tx := db.Begin()
-		for _, c := range chunked {
-			bar.Increment()
-
-			// select old record.
-			old := models.CveDetail{}
-			r := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
-			if r.RecordNotFound() || old.ID == 0 {
-				if err := tx.Create(&c).Error; err != nil {
-					tx.Rollback()
-					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-						pp.Sprintf("%v", c), err)
-				}
-				refreshedJvns = append(refreshedJvns, c.CveID)
-				continue
-			}
-
-			if !r.RecordNotFound() {
-				// select Jvn from db
-				jvn := models.Jvn{}
-				db.Model(&old).Related(&jvn, "Jvn")
-
-				if jvn.CveDetailID == 0 {
-					c.Jvn.CveDetailID = old.ID
-					if err := tx.Create(&c.Jvn).Error; err != nil {
-						tx.Rollback()
-						return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-							pp.Sprintf("%v", c.Jvn), err)
-					}
-					refreshedJvns = append(refreshedJvns, c.CveID)
-					continue
-				}
-
-				// Refresh JVN Record.
-
-				// skip if the record has already been in DB and not modified.
-				if jvn.LastModifiedDate.Equal(c.Jvn.LastModifiedDate) ||
-					jvn.LastModifiedDate.After(c.Jvn.LastModifiedDate) {
-					//  log.Debugf("Not modified. old: %s", old.CveID)
-					continue
-				} else {
-					log.Debugf("Newer record found. CveID: %s, old: %s, new: %s",
-						c.CveID, jvn.LastModifiedDate, c.Jvn.LastModifiedDate)
-				}
-
-				// Delte old References
-				refs := []models.Reference{}
-				db.Model(&jvn).Related(&refs, "References")
-				for _, r := range refs {
-					if err := tx.Unscoped().Delete(r).Error; err != nil {
-						tx.Rollback()
-						return errDelete(c, err)
-					}
-				}
-
-				// Delete old Cpes
-				cpes := []models.Cpe{}
-				db.Model(&jvn).Related(&cpes, "Cpes")
-				for _, cpe := range cpes {
-					if err := tx.Unscoped().Delete(cpe).Error; err != nil {
-						tx.Rollback()
-						return errDelete(c, err)
-					}
-				}
-
-				// Delete old Jvn
-				if err := tx.Unscoped().Delete(&jvn).Error; err != nil {
-					tx.Rollback()
-					return errDelete(c, err)
-				}
-
-				// Insert Jvn
-				c.Jvn.CveDetailID = old.ID
-				if err := tx.Create(&c.Jvn).Error; err != nil {
-					tx.Rollback()
-					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-						pp.Sprintf("%v", c.Jvn), err)
-				}
-				refreshedJvns = append(refreshedJvns, c.CveID)
-			}
-		}
-		tx.Commit()
-	}
-	bar.Finish()
-	log.Infof("Refreshed %d Jvns.", len(refreshedJvns))
-	//  log.Debugf("%v", refreshedJvns)
-	return nil
-}
-
-func errDelete(c models.CveDetail, err error) error {
-	return fmt.Errorf("Failed to delete old record. cve: %s, err: %s",
-		pp.Sprintf("%v", c), err)
 }
 
 // ConvertJvn converts Jvn structure(got from JVN) to model structure.
@@ -399,6 +183,38 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 	return
 }
 
+func chunkSlice(l []models.CveDetail, n int) chan []models.CveDetail {
+	ch := make(chan []models.CveDetail)
+
+	go func() {
+		for i := 0; i < len(l); i += n {
+			fromIdx := i
+			toIdx := i + n
+			if toIdx > len(l) {
+				toIdx = len(l)
+			}
+			ch <- l[fromIdx:toIdx]
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func getCveIDs(item jvn.Item) []string {
+	cveIDsMap := map[string]bool{}
+	for _, ref := range item.References {
+		switch ref.Source {
+		case "NVD", "CVE":
+			cveIDsMap[ref.ID] = true
+		}
+	}
+	var cveIDs []string
+	for cveID := range cveIDsMap {
+		cveIDs = append(cveIDs, cveID)
+	}
+	return cveIDs
+}
+
 func stringToFloat(str string) float64 {
 	if len(str) == 0 {
 		return 0
@@ -457,207 +273,4 @@ func toJvnTime(strtime string) (t time.Time, err error) {
 		return t, fmt.Errorf("Failed to parse time, time: %s, err: %s", strtime, err)
 	}
 	return
-}
-
-func getCveIDs(item jvn.Item) []string {
-	cveIDsMap := map[string]bool{}
-	for _, ref := range item.References {
-		switch ref.Source {
-		case "NVD", "CVE":
-			cveIDsMap[ref.ID] = true
-		}
-	}
-	var cveIDs []string
-	for cveID := range cveIDsMap {
-		cveIDs = append(cveIDs, cveID)
-	}
-	return cveIDs
-}
-
-// convertNvd converts Nvd structure(got from NVD) to model structure.
-func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
-	for _, entry := range entries {
-		//  if entry.Cvss.Score == "0" || len(entry.Cvss.Score) == 0 {
-		//      log.Warnf("Skip. CVSS Score is zero. JvnID: %s", entry.CveID)
-		//      //ignore invalid item
-		//      continue
-		//  }
-
-		// References
-		refs := []models.Reference{}
-		for _, r := range entry.References {
-			ref := models.Reference{
-				Source: r.Source,
-				Link:   r.Link.Href,
-			}
-			refs = append(refs, ref)
-		}
-
-		//  // Cpes
-		cpes := []models.Cpe{}
-		for _, c := range entry.Products {
-			cpe, err := parseCpe(c)
-			if err != nil {
-				panic(err)
-			}
-			cpes = append(cpes, cpe)
-		}
-
-		cve := models.CveDetail{
-			CveID: entry.CveID,
-			Nvd: models.Nvd{
-				Summary:               entry.Summary,
-				Score:                 stringToFloat(entry.Cvss.Score),
-				AccessVector:          entry.Cvss.AccessVector,
-				AccessComplexity:      entry.Cvss.AccessComplexity,
-				Authentication:        entry.Cvss.Authentication,
-				ConfidentialityImpact: entry.Cvss.ConfidentialityImpact,
-				IntegrityImpact:       entry.Cvss.IntegrityImpact,
-				AvailabilityImpact:    entry.Cvss.AvailabilityImpact,
-				CweID:                 entry.Cwe.ID,
-				PublishedDate:         entry.PublishedDate,
-				LastModifiedDate:      entry.LastModifiedDate,
-
-				Cpes:       cpes,
-				References: refs,
-			},
-		}
-		cves = append(cves, cve)
-	}
-	return
-}
-
-func chunkSlice(l []models.CveDetail, n int) chan []models.CveDetail {
-	ch := make(chan []models.CveDetail)
-
-	go func() {
-		for i := 0; i < len(l); i += n {
-			fromIdx := i
-			toIdx := i + n
-			if toIdx > len(l) {
-				toIdx = len(l)
-			}
-			ch <- l[fromIdx:toIdx]
-		}
-		close(ch)
-	}()
-	return ch
-}
-
-// CountNvd count nvd table
-func CountNvd() (int, error) {
-	var count int
-	if err := db.Model(&models.Nvd{}).Count(&count).Error; err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
-// InsertNvd inserts CveInformation into DB
-func InsertNvd(entries []nvd.Entry) error {
-	log.Info("Inserting CVEs...")
-
-	cves := convertNvd(entries)
-	if err := insertIntoNvd(cves); err != nil {
-		return err
-	}
-	return nil
-}
-
-// insertIntoNvd inserts CveInformation into DB
-func insertIntoNvd(cves []models.CveDetail) error {
-	refreshedNvds := []string{}
-	bar := pb.StartNew(len(cves))
-
-	for chunked := range chunkSlice(cves, 10) {
-		tx := db.Begin()
-		for _, c := range chunked {
-			bar.Increment()
-
-			//TODO rename
-			old := models.CveDetail{}
-
-			// select old record.
-			r := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
-			if r.RecordNotFound() || old.ID == 0 {
-				if err := tx.Create(&c).Error; err != nil {
-					tx.Rollback()
-					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-						pp.Sprintf("%v", c), err)
-				}
-				refreshedNvds = append(refreshedNvds, c.CveID)
-				continue
-			}
-
-			if !r.RecordNotFound() {
-				// select Nvd from db
-				nvd := models.Nvd{}
-				db.Model(&old).Related(&nvd, "Nvd")
-
-				if nvd.CveDetailID == 0 {
-					c.Nvd.CveDetailID = old.ID
-					if err := tx.Create(&c.Nvd).Error; err != nil {
-						tx.Rollback()
-						return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-							pp.Sprintf("%v", c.Nvd), err)
-					}
-					refreshedNvds = append(refreshedNvds, c.CveID)
-					continue
-				}
-
-				// Refresh to new NVD Record.
-
-				// skip if the record has already been in DB and not modified.
-				if nvd.LastModifiedDate.Equal(c.Nvd.LastModifiedDate) ||
-					nvd.LastModifiedDate.After(c.Nvd.LastModifiedDate) {
-					//  log.Debugf("Not modified. old: %s", old.CveID)
-					continue
-				} else {
-					log.Debugf("newer Record found. CveID: %s, old: %s, new: %s",
-						c.CveID, nvd.LastModifiedDate, c.Nvd.LastModifiedDate)
-				}
-
-				// Delte old References
-				refs := []models.Reference{}
-				db.Model(&nvd).Related(&refs, "References")
-				for _, r := range refs {
-					if err := tx.Unscoped().Delete(r).Error; err != nil {
-						tx.Rollback()
-						return errDelete(c, err)
-					}
-				}
-
-				// Delete old Cpes
-				cpes := []models.Cpe{}
-				db.Model(&nvd).Related(&cpes, "Cpes")
-				for _, cpe := range cpes {
-					if err := tx.Unscoped().Delete(cpe).Error; err != nil {
-						tx.Rollback()
-						return errDelete(c, err)
-					}
-				}
-
-				// Delete old Nvd
-				if err := tx.Unscoped().Delete(&nvd).Error; err != nil {
-					tx.Rollback()
-					return errDelete(c, err)
-				}
-
-				// Insert Nvd
-				c.Nvd.CveDetailID = old.ID
-				if err := tx.Create(&c.Nvd).Error; err != nil {
-					tx.Rollback()
-					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
-						pp.Sprintf("%v", c.Nvd), err)
-				}
-				refreshedNvds = append(refreshedNvds, c.CveID)
-			}
-		}
-		tx.Commit()
-	}
-	bar.Finish()
-
-	log.Infof("Refreshed %d Nvds.", len(refreshedNvds))
-	//  log.Debugf("%v", refreshedNvds)
-	return nil
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -1,0 +1,412 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/cheggaaa/pb"
+	"github.com/jinzhu/gorm"
+	"github.com/k0kubun/pp"
+	"github.com/kotakanbe/go-cve-dictionary/jvn"
+	log "github.com/kotakanbe/go-cve-dictionary/log"
+	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/kotakanbe/go-cve-dictionary/nvd"
+)
+
+// RDBDriver is Driver for RDB
+type RDBDriver struct {
+	name string
+	conn *gorm.DB
+}
+
+// Name return db name
+func (r *RDBDriver) Name() string {
+	return r.name
+}
+
+// OpenDB opens Database
+func (r *RDBDriver) OpenDB(dbType, dbPath string, debugSQL bool) (err error) {
+	r.conn, err = gorm.Open(dbType, dbPath)
+	if err != nil {
+		err = fmt.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %s", dbType, dbPath, err)
+		return
+	}
+	r.conn.LogMode(debugSQL)
+	if r.name == dialectSqlite3 {
+		r.conn.Exec("PRAGMA journal_mode=WAL;")
+	}
+	return
+}
+
+// MigrateDB migrates Database
+func (r *RDBDriver) MigrateDB() error {
+	if err := r.conn.AutoMigrate(
+		&models.CveDetail{},
+		&models.Jvn{},
+		&models.Nvd{},
+		&models.Reference{},
+		&models.Cpe{},
+	).Error; err != nil {
+		return fmt.Errorf("Failed to migrate. err: %s", err)
+	}
+
+	errMsg := "Failed to create index. err: %s"
+	if err := r.conn.Model(&models.CveDetail{}).
+		AddIndex("idx_cve_detail_cveid", "cve_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Nvd{}).
+		AddIndex("idx_nvds_cve_detail_id", "cve_detail_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Jvn{}).
+		AddIndex("idx_jvns_cve_detail_id", "cve_detail_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Cpe{}).
+		AddIndex("idx_cpes_jvn_id", "jvn_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Reference{}).
+		AddIndex("idx_references_jvn_id", "jvn_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Cpe{}).
+		AddIndex("idx_cpes_nvd_id", "nvd_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Cpe{}).
+		AddIndex("idx_cpes_cpe_name", "cpe_name").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+	if err := r.conn.Model(&models.Reference{}).
+		AddIndex("idx_references_nvd_id", "nvd_id").Error; err != nil {
+		return fmt.Errorf(errMsg, err)
+	}
+
+	return nil
+}
+
+// Get Select Cve information from DB.
+func (r *RDBDriver) Get(cveID string) (cveDetail *models.CveDetail) {
+	// Avoid null slice being null in JSON
+	emptyCveDetail := models.CveDetail{
+		Nvd: models.Nvd{
+			References: []models.Reference{},
+			Cpes:       []models.Cpe{},
+		},
+		Jvn: models.Jvn{
+			References: []models.Reference{},
+			Cpes:       []models.Cpe{},
+		},
+	}
+
+	r.conn.Where(&models.CveDetail{CveID: cveID}).First(&cveDetail)
+
+	if cveDetail.ID == 0 {
+		// Avoid null slice being null in JSON
+		return &emptyCveDetail
+	}
+
+	// JVN
+	jvn := models.Jvn{}
+	r.conn.Model(&cveDetail).Related(&jvn, "Jvn")
+	cveDetail.Jvn = jvn
+
+	if jvn.CveDetailID != 0 && jvn.ID != 0 {
+		jvnRefs := []models.Reference{}
+		r.conn.Model(&jvn).Related(&jvnRefs, "References")
+		cveDetail.Jvn.References = jvnRefs
+
+		// TODO commentout because JSON response size will be big. so Uncomment if needed.
+		//  jvnCpes := []models.Cpe{}
+		//  conn.Model(&jvn).Related(&jvnCpes, "Cpes")
+		//  c.Jvn.Cpes = jvnCpes
+		if cveDetail.Jvn.Cpes == nil {
+			cveDetail.Jvn.Cpes = []models.Cpe{}
+		}
+	}
+
+	// NVD
+	nvd := models.Nvd{}
+	r.conn.Model(&cveDetail).Related(&nvd, "Nvd")
+	cveDetail.Nvd = nvd
+
+	if nvd.CveDetailID != 0 && nvd.ID != 0 {
+		nvdRefs := []models.Reference{}
+		r.conn.Model(&nvd).Related(&nvdRefs, "References")
+		cveDetail.Nvd.References = nvdRefs
+
+		// TODO commentout because JSON response size will be big. so Uncomment if needed.
+		//  nvdCpes := []models.Cpe{}
+		//  conn.Model(&nvd).Related(&nvdCpes, "Cpes")
+		//  c.Nvd.Cpes = nvdCpes
+		if cveDetail.Nvd.Cpes == nil {
+			cveDetail.Nvd.Cpes = []models.Cpe{}
+		}
+	}
+	return cveDetail
+}
+
+// GetByCpeName Select Cve information from DB.
+func (r *RDBDriver) GetByCpeName(cpeName string) (details []*models.CveDetail) {
+	cpes := []models.Cpe{}
+	r.conn.Where(&models.Cpe{CpeName: cpeName}).Find(&cpes)
+
+	for _, cpe := range cpes {
+		var cveDetailID uint
+		if cpe.JvnID != 0 {
+			//TODO test check CPE name format of JVN table
+			jvn := models.Jvn{}
+			r.conn.Select("cve_detail_id").Where("ID = ?", cpe.JvnID).First(&jvn)
+			cveDetailID = jvn.CveDetailID
+		} else if cpe.NvdID != 0 {
+			nvd := models.Nvd{}
+			r.conn.Select("cve_detail_id").Where("ID = ?", cpe.NvdID).First(&nvd)
+			cveDetailID = nvd.CveDetailID
+		}
+
+		cveDetail := models.CveDetail{}
+		r.conn.Select("cve_id").Where("ID = ?", cveDetailID).First(&cveDetail)
+		cveID := cveDetail.CveID
+		details = append(details, r.Get(cveID))
+	}
+	return
+}
+
+// InsertJvn insert items fetched from JVN.
+func (r *RDBDriver) InsertJvn(items []jvn.Item) error {
+	log.Info("Inserting fetched CVEs...")
+
+	cves := convertJvn(items)
+	if err := r.insertIntoJvn(cves); err != nil {
+		return err
+	}
+	return nil
+}
+
+// InsertIntoJvn inserts Cve Information into DB
+func (r *RDBDriver) insertIntoJvn(cves []models.CveDetail) error {
+	var err error
+	var refreshedJvns []string
+	bar := pb.StartNew(len(cves))
+
+	for chunked := range chunkSlice(cves, 10) {
+		var tx *gorm.DB
+		tx = r.conn.Begin()
+
+		for _, c := range chunked {
+			bar.Increment()
+
+			// select old record.
+			old := models.CveDetail{}
+			c.Jvn.CveID = c.CveID
+			result := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
+			if result.RecordNotFound() || old.ID == 0 {
+				if err = tx.Create(&c).Error; err != nil {
+					tx.Rollback()
+					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+						pp.Sprintf("%v", c), err)
+				}
+				refreshedJvns = append(refreshedJvns, c.CveID)
+				continue
+			}
+
+			if !result.RecordNotFound() {
+				// select Jvn from db
+				jvn := models.Jvn{}
+				r.conn.Model(&old).Related(&jvn, "Jvn")
+
+				if jvn.CveDetailID == 0 {
+					c.Jvn.CveDetailID = old.ID
+					if err = tx.Create(&c.Jvn).Error; err != nil {
+						tx.Rollback()
+						return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+							pp.Sprintf("%v", c.Jvn), err)
+					}
+					refreshedJvns = append(refreshedJvns, c.CveID)
+					continue
+				}
+
+				// Refresh JVN Record.
+
+				// skip if the record has already been in DB and not modified.
+				if jvn.LastModifiedDate.Equal(c.Jvn.LastModifiedDate) ||
+					jvn.LastModifiedDate.After(c.Jvn.LastModifiedDate) {
+					//  log.Debugf("Not modified. old: %s", old.CveID)
+					continue
+				} else {
+					log.Debugf("Newer record found. CveID: %s, old: %s, new: %s",
+						c.CveID, jvn.LastModifiedDate, c.Jvn.LastModifiedDate)
+				}
+
+				// Delte old References
+				refs := []models.Reference{}
+				r.conn.Model(&jvn).Related(&refs, "References")
+				for _, r := range refs {
+					if err = tx.Unscoped().Delete(r).Error; err != nil {
+						tx.Rollback()
+						return errDelete(c, err)
+					}
+				}
+
+				// Delete old Cpes
+				cpes := []models.Cpe{}
+				r.conn.Model(&jvn).Related(&cpes, "Cpes")
+				for _, cpe := range cpes {
+					if err = tx.Unscoped().Delete(cpe).Error; err != nil {
+						tx.Rollback()
+						return errDelete(c, err)
+					}
+				}
+
+				// Delete old Jvn
+				if err = tx.Unscoped().Delete(&jvn).Error; err != nil {
+					tx.Rollback()
+					return errDelete(c, err)
+				}
+
+				// Insert Jvn
+				c.Jvn.CveDetailID = old.ID
+				if err = tx.Create(&c.Jvn).Error; err != nil {
+					tx.Rollback()
+					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+						pp.Sprintf("%v", c.Jvn), err)
+				}
+				refreshedJvns = append(refreshedJvns, c.CveID)
+			}
+		}
+		tx.Commit()
+	}
+	bar.Finish()
+	log.Infof("Refreshed %d Jvns.", len(refreshedJvns))
+	log.Debugf("%v", refreshedJvns)
+	return nil
+}
+
+func errDelete(c models.CveDetail, err error) error {
+	return fmt.Errorf("Failed to delete old record. cve: %s, err: %s",
+		pp.Sprintf("%v", c), err)
+}
+
+// CountNvd count nvd table
+func (r *RDBDriver) CountNvd() (int, error) {
+	var count int
+	if err := r.conn.Model(&models.Nvd{}).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// InsertNvd inserts CveInformation into DB
+func (r *RDBDriver) InsertNvd(entries []nvd.Entry) error {
+	log.Info("Inserting CVEs...")
+
+	cves := convertNvd(entries)
+	if err := r.insertIntoNvd(cves); err != nil {
+		return err
+	}
+	return nil
+}
+
+// insertIntoNvd inserts CveInformation into DB
+func (r *RDBDriver) insertIntoNvd(cves []models.CveDetail) error {
+	var err error
+	var refreshedNvds []string
+	bar := pb.StartNew(len(cves))
+
+	for chunked := range chunkSlice(cves, 10) {
+		var tx *gorm.DB
+
+		tx = r.conn.Begin()
+
+		for _, c := range chunked {
+			bar.Increment()
+
+			//TODO rename
+			old := models.CveDetail{}
+			c.Nvd.CveID = c.CveID
+
+			// select old record.
+			result := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
+			if result.RecordNotFound() || old.ID == 0 {
+				if err = tx.Create(&c).Error; err != nil {
+					tx.Rollback()
+					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+						pp.Sprintf("%v", c), err)
+				}
+				refreshedNvds = append(refreshedNvds, c.CveID)
+				continue
+			}
+
+			if !result.RecordNotFound() {
+				// select Nvd from db
+				nvd := models.Nvd{}
+				r.conn.Model(&old).Related(&nvd, "Nvd")
+
+				if nvd.CveDetailID == 0 {
+					c.Nvd.CveDetailID = old.ID
+					if err = tx.Create(&c.Nvd).Error; err != nil {
+						tx.Rollback()
+						return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+							pp.Sprintf("%v", c.Nvd), err)
+					}
+					refreshedNvds = append(refreshedNvds, c.CveID)
+					continue
+				}
+
+				// Refresh to new NVD Record.
+
+				// skip if the record has already been in DB and not modified.
+				if nvd.LastModifiedDate.Equal(c.Nvd.LastModifiedDate) ||
+					nvd.LastModifiedDate.After(c.Nvd.LastModifiedDate) {
+					//  log.Debugf("Not modified. old: %s", old.CveID)
+					continue
+				} else {
+					log.Debugf("newer Record found. CveID: %s, old: %s, new: %s",
+						c.CveID, nvd.LastModifiedDate, c.Nvd.LastModifiedDate)
+				}
+
+				// Delte old References
+				refs := []models.Reference{}
+				r.conn.Model(&nvd).Related(&refs, "References")
+				for _, r := range refs {
+					if err = tx.Unscoped().Delete(r).Error; err != nil {
+						tx.Rollback()
+						return errDelete(c, err)
+					}
+				}
+
+				// Delete old Cpes
+				cpes := []models.Cpe{}
+				r.conn.Model(&nvd).Related(&cpes, "Cpes")
+				for _, cpe := range cpes {
+					if err = tx.Unscoped().Delete(cpe).Error; err != nil {
+						tx.Rollback()
+						return errDelete(c, err)
+					}
+				}
+
+				// Delete old Nvd
+				if err = tx.Unscoped().Delete(&nvd).Error; err != nil {
+					tx.Rollback()
+					return errDelete(c, err)
+				}
+
+				// Insert Nvd
+				c.Nvd.CveDetailID = old.ID
+				if err = tx.Create(&c.Nvd).Error; err != nil {
+					tx.Rollback()
+					return fmt.Errorf("Failed to insert. cve: %s, err: %s",
+						pp.Sprintf("%v", c.Nvd), err)
+				}
+				refreshedNvds = append(refreshedNvds, c.CveID)
+			}
+		}
+		tx.Commit()
+	}
+	bar.Finish()
+
+	log.Infof("Refreshed %d Nvds.", len(refreshedNvds))
+	//  log.Debugf("%v", refreshedNvds)
+	return nil
+}

--- a/db/redis.go
+++ b/db/redis.go
@@ -1,0 +1,272 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cheggaaa/pb"
+	"github.com/go-redis/redis"
+	"github.com/kotakanbe/go-cve-dictionary/jvn"
+	log "github.com/kotakanbe/go-cve-dictionary/log"
+	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/kotakanbe/go-cve-dictionary/nvd"
+)
+
+/**
+# Redis Data Structure
+
+- HASH
+  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
+  │NO │  HASH  │  FIELD   │  VALUE   │             PURPOSE             │
+  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
+  │ 1 │ $CVEID │NVD or JVN│ $CVEJSON │     TO GET CVEJSON BY CVEID     │
+  ├───┼────────┼──────────┼──────────┼─────────────────────────────────┤
+  │ 2 │  CPE   │ $CPENAME │ $CPEJSON │    TO GET CPEJSON BY CPENAME    │
+  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+
+- ZINDEX
+  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
+  │NO │  KEY   │  SCORE   │  MEMBER  │             PURPOSE             │
+  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
+  │ 3 │$CPENAME│    0     │  $CVEID  │TO GET RELATED []CVEID BY CPENAME│
+  ├───┼────────┼──────────┼──────────┼─────────────────────────────────┤
+  │ 4 │CPENAME │    0     │ $CPENAME │   TO GET ALL CPENAME QUICKLY    │
+  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+**/
+
+// RedisDriver is Driver for Redis
+type RedisDriver struct {
+	name string
+	conn *redis.Client
+}
+
+// Name return db name
+func (r *RedisDriver) Name() string {
+	return r.name
+}
+
+// OpenDB opens Database
+func (r *RedisDriver) OpenDB(dbType, dbPath string, debugSQL bool) (err error) {
+	if err = r.connectRedis(dbPath); err != nil {
+		err = fmt.Errorf("Failed to open DB. dbtype: %s, dbpath: %s, err: %s", dbType, dbPath, err)
+	}
+	return
+}
+
+func (r *RedisDriver) connectRedis(dbPath string) error {
+	var err error
+	var option *redis.Options
+	if option, err = redis.ParseURL(dbPath); err != nil {
+		log.Error(err)
+		return err
+	}
+	r.conn = redis.NewClient(option)
+	if err = r.conn.Ping().Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MigrateDB migrates Database
+func (r *RedisDriver) MigrateDB() error {
+	return nil
+}
+
+// Get Select Cve information from DB.
+func (r *RedisDriver) Get(cveID string) (cveDetail *models.CveDetail) {
+	// Avoid null slice being null in JSON
+	emptyCveDetail := models.CveDetail{
+		Nvd: models.Nvd{
+			References: []models.Reference{},
+			Cpes:       []models.Cpe{},
+		},
+		Jvn: models.Jvn{
+			References: []models.Reference{},
+			Cpes:       []models.Cpe{},
+		},
+	}
+
+	var result *redis.StringStringMapCmd
+	if result = r.conn.HGetAll(cveID); result.Err() != nil {
+		log.Error(result.Err())
+		return &emptyCveDetail
+	}
+
+	jvn := models.Jvn{
+		References: []models.Reference{},
+		Cpes:       []models.Cpe{},
+	}
+
+	var err error
+	if j, ok := result.Val()["Jvn"]; ok {
+		if err = json.Unmarshal([]byte(j), &jvn); err != nil {
+			log.Errorf("Failed to Unmarshal json. err : %s", err)
+			return &emptyCveDetail
+		}
+	}
+
+	nvd := models.Nvd{
+		References: []models.Reference{},
+		Cpes:       []models.Cpe{},
+	}
+	if j, ok := result.Val()["Nvd"]; ok {
+		if err = json.Unmarshal([]byte(j), &nvd); err != nil {
+			log.Errorf("Failed to Unmarshal json. err : %s", err)
+			return &emptyCveDetail
+		}
+	}
+
+	cveDetail = &models.CveDetail{
+		CveID: cveID,
+		Nvd:   nvd,
+		Jvn:   jvn,
+	}
+
+	return cveDetail
+}
+
+// GetByCpeName Select Cve information from DB.
+func (r *RedisDriver) GetByCpeName(cpeName string) (details []*models.CveDetail) {
+	var result *redis.StringSliceCmd
+	if result = r.conn.ZRange(cpeName, 0, -1); result.Err() != nil {
+		log.Error(result.Err())
+		return details
+	}
+
+	for _, v := range result.Val() {
+		details = append(details, r.Get(v))
+	}
+	return
+}
+
+// InsertJvn insert items fetched from JVN.
+func (r *RedisDriver) InsertJvn(items []jvn.Item) error {
+	log.Info("Inserting fetched CVEs...")
+
+	cves := convertJvn(items)
+	if err := r.insertIntoJvn(cves); err != nil {
+		return err
+	}
+	return nil
+}
+
+// InsertIntoJvn inserts Cve Information into DB
+func (r *RedisDriver) insertIntoJvn(cves []models.CveDetail) error {
+	var err error
+	var refreshedJvns []string
+	bar := pb.StartNew(len(cves))
+
+	for chunked := range chunkSlice(cves, 10) {
+		var pipe redis.Pipeliner
+		pipe = r.conn.Pipeline()
+		for _, c := range chunked {
+			bar.Increment()
+
+			var jj []byte
+			c.Jvn.CveID = c.CveID
+			if jj, err = json.Marshal(c.Jvn); err != nil {
+				return fmt.Errorf("Failed to marshal json. err: %s", err)
+			}
+			refreshedJvns = append(refreshedJvns, c.CveID)
+			if result := pipe.HSet(c.CveID, "Jvn", string(jj)); result.Err() != nil {
+				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
+			}
+
+			for _, cpe := range c.Jvn.Cpes {
+				var jc []byte
+				if jc, err = json.Marshal(cpe); err != nil {
+					return fmt.Errorf("Failed to marshal json. err: %s", err)
+				}
+
+				if result := pipe.HSet("Cpe", cpe.CpeName, jc); result.Err() != nil {
+					return fmt.Errorf("Failed to HSet cpe. err: %s", result.Err())
+				}
+				if result := pipe.ZAdd(cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
+					return fmt.Errorf("Failed to ZAdd cpe name. err: %s", result.Err())
+				}
+				if result := pipe.ZAdd("CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
+					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
+				}
+			}
+		}
+		if _, err = pipe.Exec(); err != nil {
+			return fmt.Errorf("Failed to exec pipeline. err: %s", err)
+		}
+	}
+	bar.Finish()
+	log.Infof("Refreshed %d Jvns.", len(refreshedJvns))
+	//  log.Debugf("%v", refreshedJvns)
+	return nil
+}
+
+// CountNvd count nvd table
+func (r *RedisDriver) CountNvd() (int, error) {
+	var result *redis.StringSliceCmd
+	if result = r.conn.Keys("CVE*"); result.Err() != nil {
+		return 0, result.Err()
+	}
+	return len(result.Val()), nil
+}
+
+// InsertNvd inserts CveInformation into DB
+func (r *RedisDriver) InsertNvd(entries []nvd.Entry) error {
+	log.Info("Inserting CVEs...")
+
+	cves := convertNvd(entries)
+	if err := r.insertIntoNvd(cves); err != nil {
+		return err
+	}
+	return nil
+}
+
+// insertIntoNvd inserts CveInformation into DB
+func (r *RedisDriver) insertIntoNvd(cves []models.CveDetail) error {
+	var err error
+	var refreshedNvds []string
+	bar := pb.StartNew(len(cves))
+
+	for chunked := range chunkSlice(cves, 10) {
+		var pipe redis.Pipeliner
+		pipe = r.conn.Pipeline()
+		for _, c := range chunked {
+			bar.Increment()
+
+			var jn []byte
+			c.Nvd.CveID = c.CveID
+			if jn, err = json.Marshal(c.Nvd); err != nil {
+				return fmt.Errorf("Failed to marshal json. err: %s", err)
+			}
+			refreshedNvds = append(refreshedNvds, c.CveID)
+			if result := pipe.HSet(c.CveID, "Nvd", string(jn)); result.Err() != nil {
+				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
+			}
+
+			for _, cpe := range c.Nvd.Cpes {
+				var jc []byte
+				if jc, err = json.Marshal(cpe); err != nil {
+					return fmt.Errorf("Failed to marshal json. err: %s", err)
+				}
+
+				if result := pipe.HSet("Cpe", cpe.CpeName, jc); result.Err() != nil {
+					return fmt.Errorf("Failed to HSet cpe. err: %s", result.Err())
+				}
+				if result := pipe.ZAdd(cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
+					return fmt.Errorf("Failed to ZAdd cpe name. err: %s", result.Err())
+				}
+				if result := pipe.ZAdd("CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
+					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
+				}
+			}
+		}
+		if _, err = pipe.Exec(); err != nil {
+			return fmt.Errorf("Failed to exec pipeline. err: %s", err)
+		}
+	}
+	bar.Finish()
+
+	log.Infof("Refreshed %d Nvds.", len(refreshedNvds))
+	//  log.Debugf("%v", refreshedNvds)
+	return nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -82,6 +82,7 @@ type Nvd struct {
 	CveDetailID uint `json:"-" xml:"-"`
 
 	// Increased size of summary to ensure we can fit arbitrary CVE content.
+	CveID                 string
 	Summary               string  `gorm:"size:4096"`
 	Score                 float64 // 1 to 10
 	AccessVector          string
@@ -196,6 +197,7 @@ type Jvn struct {
 	gorm.Model  `json:"-" xml:"-"`
 	CveDetailID uint `json:"-" xml:"-"`
 
+	CveID   string
 	Title   string
 	Summary string `gorm:"size:8192"`
 	JvnLink string

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/kotakanbe/go-cve-dictionary/config"
-	db "github.com/kotakanbe/go-cve-dictionary/db"
+	"github.com/kotakanbe/go-cve-dictionary/db"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/engine/standard"
@@ -15,7 +15,7 @@ import (
 )
 
 // Start starts CVE dictionary HTTP Server.
-func Start(logDir string) error {
+func Start(logDir string, driver db.DB) error {
 	e := echo.New()
 	e.SetDebug(config.Conf.Debug)
 
@@ -41,8 +41,8 @@ func Start(logDir string) error {
 
 	// Routes
 	e.Get("/health", health())
-	e.Get("/cves/:id", getCve())
-	e.Post("/cpes", getCveByCpeName())
+	e.Get("/cves/:id", getCve(driver))
+	e.Post("/cpes", getCveByCpeName(driver))
 
 	bindURL := fmt.Sprintf("%s:%s", config.Conf.Bind, config.Conf.Port)
 	log.Infof("Listening on %s", bindURL)
@@ -59,11 +59,11 @@ func health() echo.HandlerFunc {
 }
 
 // Handler
-func getCve() echo.HandlerFunc {
+func getCve(driver db.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		cveid := c.Param("id")
-		cveDetail := db.Get(cveid)
-		return c.JSON(http.StatusOK, cveDetail)
+		cveDetail := driver.Get(cveid)
+		return c.JSON(http.StatusOK, &cveDetail)
 	}
 }
 
@@ -71,14 +71,14 @@ type cpeName struct {
 	Name string `form:"name"`
 }
 
-func getCveByCpeName() echo.HandlerFunc {
+func getCveByCpeName(driver db.DB) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		cpe := cpeName{}
 		err := c.Bind(&cpe)
 		if err != nil {
 			return err
 		}
-		cveDetails := db.GetByCpeName(cpe.Name)
-		return c.JSON(http.StatusOK, cveDetails)
+		cveDetails := driver.GetByCpeName(cpe.Name)
+		return c.JSON(http.StatusOK, &cveDetails)
 	}
 }


### PR DESCRIPTION
I added the dbtype of redis.

I tested this as follow.

1. prepare docker-compose.yml

```
$ vim docker-compose.yml
version: "3"

services:
  redis:
    image: redis
    ports:
      - "6379:6379"
  redisCommander:
    image: tenstartups/redis-commander
    command: --redis-host redis
    links:
      - redis:redis
    ports:
      - "8081:8081"
```

2. run redis docker with GUI

```
$ docker-compose up -d
```

3. fetchjvn

```
$ go-cve-dictionary  fetchjvn  -last2y -debug  -dbtype redis -dbpath "redis://localhost/0"
```

4. fetchnvd

```
$ go-cve-dictionary  fetchnvd  -last2y -debug  -dbtype redis -dbpath "redis://localhost/0"
```

5. confirm the data

access to `localhost:8081`

- CVE
  - ![2017-06-05 3 50 27](https://cloud.githubusercontent.com/assets/8997330/26764454/2d26155e-49a2-11e7-9cf9-78b2fa7773c3.png)
- CPE
  - ![2017-06-05 3 53 14](https://cloud.githubusercontent.com/assets/8997330/26764482/916cc792-49a2-11e7-97da-7844f52cb66d.png)

6. server

```
$ go-cve-dictionary  server  -dbtype redis -dbpath "redis://localhost/0"
```

7. get cve data by cveid

```
$ curl -s  http://127.0.0.1:1323/cves/CVE-2017-9064 | jq "." | head -20
{
  "CveID": "CVE-2017-9064",
  "Nvd": {
    "Summary": "In WordPress before 4.7.5, a Cross Site Request Forgery (CSRF) vulnerability exists in the filesystem credentials dialog because a nonce is not required for updating credentials.",
    "Score": 6.8,
    "AccessVector": "NETWORK",
    "AccessComplexity": "MEDIUM",
    "Authentication": "NONE",
    "ConfidentialityImpact": "PARTIAL",
    "IntegrityImpact": "PARTIAL",
    "AvailabilityImpact": "PARTIAL",
    "Cpes": [
      {
        "CpeName": "cpe:/a:wordpress:wordpress:4.7.4",
        "Part": "a",
        "Vendor": "wordpress",
        "Product": "wordpress",
        "Version": "4.7.4",
        "VendorUpdate": "",
        "Edition": "",
```

8. get cve data by cpename

```
$ curl -s  -H "Accept: application/json" -H "Content-type: application/json" -X POST -d '{ "name": "cpe:/h:amd:athlon_ii_640_x4"}' http://localhost:1323/cpes | jq "." | head -20
[
  {
    "CveID": "CVE-2017-5927",
    "Nvd": {
      "Summary": "Page table walks conducted by the MMU during virtual to physical address translation leave a trace in the last level cache of modern ARM processors. By performing a side-channel attack on the MMU operations, it is possible to leak data and code pointers from JavaScript, breaking ASLR.",
      "Score": 5,
      "AccessVector": "NETWORK",
      "AccessComplexity": "LOW",
      "Authentication": "NONE",
      "ConfidentialityImpact": "PARTIAL",
      "IntegrityImpact": "NONE",
      "AvailabilityImpact": "NONE",
      "Cpes": [
        {
          "CpeName": "cpe:/h:amd:athlon_ii_640_x4:-",
          "Part": "h",
          "Vendor": "amd",
          "Product": "athlon_ii_640_x4",
          "Version": "-",
          "VendorUpdate": "",
```