### PR TITLE
[BreakingChange] change redis keyname

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -10,19 +10,6 @@ import (
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/nvd"
-	// Required MySQL.  See http://jinzhu.me/gorm/database.html#connecting-to-a-database
-	_ "github.com/jinzhu/gorm/dialects/mysql"
-	_ "github.com/jinzhu/gorm/dialects/postgres"
-	// Required SQLite3.
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
-)
-
-// Supported DB dialects.
-const (
-	dialectSqlite3    = "sqlite3"
-	dialectMysql      = "mysql"
-	dialectPostgreSQL = "postgres"
-	dialectRedis      = "redis"
 )
 
 // DB is interface for a database driver

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -10,6 +10,18 @@ import (
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/kotakanbe/go-cve-dictionary/nvd"
+	// Required MySQL.  See http://jinzhu.me/gorm/database.html#connecting-to-a-database
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	// Required SQLite3.
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+// Supported DB dialects.
+const (
+	dialectSqlite3    = "sqlite3"
+	dialectMysql      = "mysql"
+	dialectPostgreSQL = "postgres"
 )
 
 // RDBDriver is Driver for RDB

--- a/db/redis.go
+++ b/db/redis.go
@@ -16,25 +16,30 @@ import (
 # Redis Data Structure
 
 - HASH
-  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
-  │NO │  HASH  │  FIELD   │  VALUE   │             PURPOSE             │
-  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
-  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
-  │ 1 │ $CVEID │NVD or JVN│ $CVEJSON │     TO GET CVEJSON BY CVEID     │
-  ├───┼────────┼──────────┼──────────┼─────────────────────────────────┤
-  │ 2 │  CPE   │ $CPENAME │ $CPEJSON │    TO GET CPEJSON BY CPENAME    │
-  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+  ┌───┬────────────┬──────────┬──────────┬─────────────────────────────────┐
+  │NO │    HASH    │  FIELD   │  VALUE   │             PURPOSE             │
+  └───┴────────────┴──────────┴──────────┴─────────────────────────────────┘
+  ┌───┬────────────┬──────────┬──────────┬─────────────────────────────────┐
+  │ 1 │ CVE#$CVEID │NVD or JVN│ $CVEJSON │     TO GET CVEJSON BY CVEID     │
+  ├───┼────────────┼──────────┼──────────┼─────────────────────────────────┤
+  │ 2 │  CVE#CPE   │ $CPENAME │ $CPEJSON │    TO GET CPEJSON BY CPENAME    │
+  └───┴────────────┴──────────┴──────────┴─────────────────────────────────┘
 
-- ZINDEX
-  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
-  │NO │  KEY   │  SCORE   │  MEMBER  │             PURPOSE             │
-  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
-  ┌───┬────────┬──────────┬──────────┬─────────────────────────────────┐
-  │ 3 │$CPENAME│    0     │  $CVEID  │TO GET RELATED []CVEID BY CPENAME│
-  ├───┼────────┼──────────┼──────────┼─────────────────────────────────┤
-  │ 4 │CPENAME │    0     │ $CPENAME │   TO GET ALL CPENAME QUICKLY    │
-  └───┴────────┴──────────┴──────────┴─────────────────────────────────┘
+- ZINDE  X
+  ┌───┬────────────┬──────────┬──────────┬─────────────────────────────────┐
+  │NO │    KEY     │  SCORE   │  MEMBER  │             PURPOSE             │
+  └───┴────────────┴──────────┴──────────┴─────────────────────────────────┘
+  ┌───┬────────────┬──────────┬──────────┬─────────────────────────────────┐
+  │ 3 │CVE#$CPENAME│    0     │  $CVEID  │TO GET RELATED []CVEID BY CPENAME│
+  ├───┼────────────┼──────────┼──────────┼─────────────────────────────────┤
+  │ 4 │CVE#CPENAME │    0     │ $CPENAME │   TO GET ALL CPENAME QUICKLY    │
+  └───┴────────────┴──────────┴──────────┴─────────────────────────────────┘
 **/
+
+const (
+	dialectRedis  = "redis"
+	hashKeyPrefix = "CVE#"
+)
 
 // RedisDriver is Driver for Redis
 type RedisDriver struct {
@@ -89,7 +94,7 @@ func (r *RedisDriver) Get(cveID string) *models.CveDetail {
 	}
 
 	var result *redis.StringStringMapCmd
-	if result = r.conn.HGetAll(cveID); result.Err() != nil {
+	if result = r.conn.HGetAll(hashKeyPrefix + cveID); result.Err() != nil {
 		log.Error(result.Err())
 		return &emptyCveDetail
 	}
@@ -130,7 +135,7 @@ func (r *RedisDriver) Get(cveID string) *models.CveDetail {
 // GetByCpeName Select Cve information from DB.
 func (r *RedisDriver) GetByCpeName(cpeName string) (details []*models.CveDetail) {
 	var result *redis.StringSliceCmd
-	if result = r.conn.ZRange(cpeName, 0, -1); result.Err() != nil {
+	if result = r.conn.ZRange(hashKeyPrefix+cpeName, 0, -1); result.Err() != nil {
 		log.Error(result.Err())
 		return details
 	}
@@ -180,13 +185,13 @@ func (r *RedisDriver) insertIntoJvn(cves []models.CveDetail) error {
 					return fmt.Errorf("Failed to marshal json. err: %s", err)
 				}
 
-				if result := pipe.HSet("Cpe", cpe.CpeName, jc); result.Err() != nil {
+				if result := pipe.HSet(hashKeyPrefix+"Cpe", cpe.CpeName, jc); result.Err() != nil {
 					return fmt.Errorf("Failed to HSet cpe. err: %s", result.Err())
 				}
-				if result := pipe.ZAdd(cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
+				if result := pipe.ZAdd(hashKeyPrefix+cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe name. err: %s", result.Err())
 				}
-				if result := pipe.ZAdd("CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
+				if result := pipe.ZAdd(hashKeyPrefix+"CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
 			}
@@ -204,7 +209,7 @@ func (r *RedisDriver) insertIntoJvn(cves []models.CveDetail) error {
 // CountNvd count nvd table
 func (r *RedisDriver) CountNvd() (int, error) {
 	var result *redis.StringSliceCmd
-	if result = r.conn.Keys("CVE*"); result.Err() != nil {
+	if result = r.conn.Keys(hashKeyPrefix + "CVE*"); result.Err() != nil {
 		return 0, result.Err()
 	}
 	return len(result.Val()), nil
@@ -239,7 +244,7 @@ func (r *RedisDriver) insertIntoNvd(cves []models.CveDetail) error {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
 			refreshedNvds = append(refreshedNvds, c.CveID)
-			if result := pipe.HSet(c.CveID, "Nvd", string(jn)); result.Err() != nil {
+			if result := pipe.HSet(hashKeyPrefix+c.CveID, "Nvd", string(jn)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 
@@ -249,13 +254,13 @@ func (r *RedisDriver) insertIntoNvd(cves []models.CveDetail) error {
 					return fmt.Errorf("Failed to marshal json. err: %s", err)
 				}
 
-				if result := pipe.HSet("Cpe", cpe.CpeName, jc); result.Err() != nil {
+				if result := pipe.HSet(hashKeyPrefix+"Cpe", cpe.CpeName, jc); result.Err() != nil {
 					return fmt.Errorf("Failed to HSet cpe. err: %s", result.Err())
 				}
-				if result := pipe.ZAdd(cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
+				if result := pipe.ZAdd(hashKeyPrefix+cpe.CpeName, redis.Z{0, c.CveID}); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe name. err: %s", result.Err())
 				}
-				if result := pipe.ZAdd("CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
+				if result := pipe.ZAdd(hashKeyPrefix+"CpeName", redis.Z{0, cpe.CpeName}); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
 			}


### PR DESCRIPTION
I add prefix("CVE#") into redis hash key because we can use the redis database as go-cvedictionary backend along with other dictionary(ex. ovaldictioanry)