### PR TITLE
change logrus package name and update other package version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,22 +2,16 @@
 
 
 [[projects]]
-  branch = "master"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "10f801ebc38b33738c9d17d50860f484a0988ff5"
-
-[[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  revision = "7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877"
-  version = "v5"
+  revision = "4918b99a7cb949bb295f3c7bbaf24b577d806e35"
+  version = "v6"
 
 [[projects]]
   name = "github.com/cheggaaa/pb"
   packages = ["."]
-  revision = "0817e3a1f8de9e3c78b159699b3c07d53e24a963"
-  version = "v1.0.11"
+  revision = "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2"
+  version = "v1.0.15"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
@@ -28,8 +22,8 @@
 [[projects]]
   name = "github.com/go-redis/redis"
   packages = [".","internal","internal/consistenthash","internal/hashtag","internal/pool","internal/proto"]
-  revision = "663bb76bcc3763c41877b63671003705a47289c5"
-  version = "v6.4.1"
+  revision = "e14976b254c5bc5f399dd0ae9314b1d02a176897"
+  version = "v6.5.0"
 
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
@@ -65,7 +59,7 @@
   branch = "master"
   name = "github.com/kotakanbe/logrus-prefixed-formatter"
   packages = ["."]
-  revision = "e7519b8c80ba008a3bfc57ffa31232bf2a77f455"
+  revision = "5ea278a9a3f980f7cdf1dc787dc4a85ac72502d9"
 
 [[projects]]
   name = "github.com/labstack/echo"
@@ -76,20 +70,20 @@
 [[projects]]
   name = "github.com/labstack/gommon"
   packages = ["bytes","color","log","random"]
-  revision = "9cedb429ffbe71a32a3ae7c65fd109cb7ae07804"
-  version = "v0.2.0"
+  revision = "1121fd3e243c202482226a7afe4dcd07ffc4139a"
+  version = "v0.2.1"
 
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
   packages = [".","hstore","oid"]
-  revision = "2704adc878c21e1329f46f6e56a1c387d788ff94"
+  revision = "8837942c3e09574accbc5f150e2c5e057189cace"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  revision = "d228849504861217f796da67fae4f6e347643f15"
-  version = "v0.0.7"
+  revision = "941b50ebc6efddf4c41c8e4537a5f68a4e686b24"
+  version = "v0.0.8"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -136,8 +130,14 @@
 [[projects]]
   name = "github.com/rifflock/lfshook"
   packages = ["."]
-  revision = "1ae91782cf87524466b000ea12d8291ea48269be"
-  version = "1.5"
+  revision = "6844c808343cb8fa357d7f141b1b990e05d24e41"
+  version = "1.7"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "3d4380f53a34dcdc95f0c1db702615992b38d9a4"
 
 [[projects]]
   branch = "master"
@@ -153,25 +153,31 @@
 
 [[projects]]
   branch = "master"
+  name = "go4.org"
+  packages = ["syncutil"]
+  revision = "034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/net"
   packages = ["context","idna","publicsuffix"]
-  revision = "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d"
+  revision = "455220fa52c866a8aa14ff5e8cc68cde16b8395e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "39e3dc274464e7d2f663aa606a830611bae5f1db"
+  revision = "90796e5a05ce440b41c768bd9af257005e470461"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "f4b4367115ec2de254587813edaa901bc1c723a8"
+  revision = "6353ef0f924300eea566d3438817aa4d3374817e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "66f23fe639c35f33e23f9b48ffd1489aa8f41fc511b47124103b1afa81379067"
+  inputs-digest = "38bdc26a7e008d3202f717addef99b0a0a7adaedca19e9994c625533a14dff04"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,8 +1,12 @@
 
 [[constraint]]
+  name = "github.com/sirupsen/logrus"
   branch = "master"
-  name = "github.com/Sirupsen/logrus"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/kotakanbe/logrus-prefixed-formatter"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/cheggaaa/pb"
+  branch = "master"

--- a/jvn/jvn.go
+++ b/jvn/jvn.go
@@ -134,6 +134,7 @@ func fetchJvnConcurrently(urls []string) (allItems []Item, err error) {
 		}
 		bar.Increment()
 	}
+	bar.Finish()
 	//  bar.FinishPrint("Finished to fetch CVE information from JVN.")
 	if 0 < len(errs) {
 		return allItems, fmt.Errorf("%s", errs)

--- a/log/log.go
+++ b/log/log.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Sirupsen/logrus"
 	formatter "github.com/kotakanbe/logrus-prefixed-formatter"
 	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Entry

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -132,6 +132,7 @@ func fetchFeedFileConcurrently(urls []string) (nvds []Nvd, err error) {
 		}
 		bar.Increment()
 	}
+	bar.Finish()
 	//  bar.FinishPrint("Finished to fetch CVE information from JVN.")
 	if 0 < len(errs) {
 		return nvds, fmt.Errorf("%s", errs)


### PR DESCRIPTION
This errors occurred.

```
grouped write of manifest, lock and vendor: error while writing out vendor tree: error while exporting github.com/sirupsen/logrus: /var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.gitignore already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.travis.yml already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/CHANGELOG.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/LICENSE already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/doc.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/basic/basic.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/hook/hook.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/exported.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hook_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_appengine.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_bsd.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_linux.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_notwindows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_solaris.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_windows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/writer.go already exists, no checkout
```

Packages conflict with uppercase and lowercase, because logrus changed packagename to lowercase.
https://github.com/sirupsen/logrus/issues/553

I want to update all vuls package's logrus package name to avoid this errors.
Target repositories are below.

1. kotakanbe/logrus-prefixed-formatter
1. kotakanbe/go-cve-dictionary
1. kotakanbe/goval-dictionary
1. future-architect/vuls