### PR TITLE
[WIP]output diff only when using redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ go-cve-dictionary
 *.sqlite3-shm
 *.sqlite3-wal
 tags
+NvdDiff.json
+JvnDiff.json

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -110,24 +110,6 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/moul/http2curl"
-  packages = ["."]
-  revision = "4e24498b31dba4683efb9d35c1c8a91e2eda28c8"
-
-[[projects]]
-  name = "github.com/parnurzeal/gorequest"
-  packages = ["."]
-  revision = "a578a48e8d6ca8b01a3b18314c43c6716bb5f5a3"
-  version = "v0.2.15"
-
-[[projects]]
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
-
-[[projects]]
   name = "github.com/rifflock/lfshook"
   packages = ["."]
   revision = "6844c808343cb8fa357d7f141b1b990e05d24e41"
@@ -160,7 +142,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","idna","publicsuffix"]
+  packages = ["context"]
   revision = "455220fa52c866a8aa14ff5e8cc68cde16b8395e"
 
 [[projects]]
@@ -169,15 +151,9 @@
   packages = ["unix"]
   revision = "90796e5a05ce440b41c768bd9af257005e470461"
 
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "6353ef0f924300eea566d3438817aa4d3374817e"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "38bdc26a7e008d3202f717addef99b0a0a7adaedca19e9994c625533a14dff04"
+  inputs-digest = "ee0fb58a70b4e4bf7db161b3d1acc37f55e07b94897d02a0c5e0db33f67aff31"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ fetchnvd:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-debug-diff]
                 [-log-dir]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
@@ -232,6 +233,8 @@ For the first time, run the blow command to fetch data for entire period. (It ta
         Database type to store data in (sqlite3, mysql ,postgres or redis supported) (default "sqlite3")
   -debug
         debug mode
+  -debug-diff
+        Chack CVE diff between the previous (only redis)
   -debug-sql
         SQL debug mode
   -http-proxy string
@@ -280,6 +283,7 @@ fetchjvn:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-debug-diff]
                 [-log-dir]
 
   -dbpath string
@@ -288,6 +292,8 @@ fetchjvn:
         Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
   -debug
         debug mode
+  -debug-diff
+        Chack CVE diff between the previous (only redis)
   -debug-sql
         SQL debug mode
   -http-proxy string

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -17,9 +17,10 @@ import (
 
 // FetchJvnCmd is Subcommand for fetch JVN information.
 type FetchJvnCmd struct {
-	debug    bool
-	debugSQL bool
-	logDir   string
+	debug     bool
+	debugSQL  bool
+	debugDiff bool
+	logDir    string
 
 	dbpath   string
 	dbtype   string
@@ -50,6 +51,7 @@ func (*FetchJvnCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-debug-diff]
 		[-log-dir=/path/to/log]
 
 `
@@ -61,6 +63,8 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 		"debug mode")
 	f.BoolVar(&p.debugSQL, "debug-sql", false,
 		"SQL debug mode")
+	f.BoolVar(&p.debugDiff, "debug-diff", false,
+		"Chack CVE diff between the previous (only redis)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -94,6 +98,7 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	log.Initialize(p.logDir)
 
 	c.Conf.DebugSQL = p.debugSQL
+	c.Conf.DebugDiff = p.debugDiff
 	c.Conf.Debug = p.debug
 	if c.Conf.Debug {
 		log.SetDebug()
@@ -171,7 +176,7 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	log.Infof("Inserting JVN into DB (%s).", driver.Name())
-	if err := driver.InsertJvn(items); err != nil {
+	if err := driver.InsertJvn(items, c.Conf.DebugDiff); err != nil {
 		log.Fatalf("Failed to inert. dbpath: %s, err: %s", c.Conf.DBPath, err)
 		return subcommands.ExitFailure
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -17,9 +17,10 @@ import (
 
 // FetchNvdCmd is Subcommand for fetch Nvd information.
 type FetchNvdCmd struct {
-	debug    bool
-	debugSQL bool
-	logDir   string
+	debug     bool
+	debugSQL  bool
+	debugDiff bool
+	logDir    string
 
 	dbpath string
 	dbtype string
@@ -47,6 +48,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-debug-diff]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
@@ -61,6 +63,8 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"debug mode")
 	f.BoolVar(&p.debugSQL, "debug-sql", false,
 		"SQL debug mode")
+	f.BoolVar(&p.debugDiff, "debug-diff", false,
+		"Chack CVE diff between the previous (only redis)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -91,6 +95,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	log.Initialize(p.logDir)
 
 	c.Conf.DebugSQL = p.debugSQL
+	c.Conf.DebugDiff = p.debugDiff
 	c.Conf.Debug = p.debug
 	if c.Conf.Debug {
 		log.SetDebug()
@@ -165,7 +170,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	}
 
 	log.Infof("Inserting NVD into DB (%s).", driver.Name())
-	if err := driver.InsertNvd(entries); err != nil {
+	if err := driver.InsertNvd(entries, c.Conf.DebugDiff); err != nil {
 		log.Errorf("Failed to inert. dbpath: %s, err: %s",
 			c.Conf.DBPath, err)
 		return subcommands.ExitFailure

--- a/config/config.go
+++ b/config/config.go
@@ -10,8 +10,9 @@ var Conf Config
 
 // Config has config
 type Config struct {
-	Debug    bool
-	DebugSQL bool
+	Debug     bool
+	DebugSQL  bool
+	DebugDiff bool
 
 	DumpPath string
 	DBPath   string

--- a/db/db.go
+++ b/db/db.go
@@ -19,8 +19,8 @@ type DB interface {
 	MigrateDB() error
 	Get(string) *models.CveDetail
 	GetByCpeName(string) []*models.CveDetail
-	InsertJvn([]jvn.Item) error
-	InsertNvd([]nvd.Entry) error
+	InsertJvn([]jvn.Item, bool) error
+	InsertNvd([]nvd.Entry, bool) error
 	CountNvd() (int, error)
 }
 
@@ -67,6 +67,7 @@ func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
 		cve := models.CveDetail{
 			CveID: entry.CveID,
 			Nvd: models.Nvd{
+				CveID:                 entry.CveID,
 				Summary:               entry.Summary,
 				Score:                 stringToFloat(entry.Cvss.Score),
 				AccessVector:          entry.Cvss.AccessVector,
@@ -148,6 +149,7 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 
 			// JVN
 			Jvn: models.Jvn{
+				CveID:   cveID,
 				Title:   strings.Replace(item.Title, "\r", "", -1),
 				Summary: strings.Replace(item.Description, "\r", "", -1),
 				JvnLink: item.Link,

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -187,7 +187,7 @@ func (r *RDBDriver) GetByCpeName(cpeName string) (details []*models.CveDetail) {
 }
 
 // InsertJvn insert items fetched from JVN.
-func (r *RDBDriver) InsertJvn(items []jvn.Item) error {
+func (r *RDBDriver) InsertJvn(items []jvn.Item, debugDiff bool) error {
 	log.Info("Inserting fetched CVEs...")
 
 	cves := convertJvn(items)
@@ -212,7 +212,6 @@ func (r *RDBDriver) insertIntoJvn(cves []models.CveDetail) error {
 
 			// select old record.
 			old := models.CveDetail{}
-			c.Jvn.CveID = c.CveID
 			result := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)
 			if result.RecordNotFound() || old.ID == 0 {
 				if err = tx.Create(&c).Error; err != nil {
@@ -311,7 +310,7 @@ func (r *RDBDriver) CountNvd() (int, error) {
 }
 
 // InsertNvd inserts CveInformation into DB
-func (r *RDBDriver) InsertNvd(entries []nvd.Entry) error {
+func (r *RDBDriver) InsertNvd(entries []nvd.Entry, debugDiff bool) error {
 	log.Info("Inserting CVEs...")
 
 	cves := convertNvd(entries)
@@ -337,7 +336,6 @@ func (r *RDBDriver) insertIntoNvd(cves []models.CveDetail) error {
 
 			//TODO rename
 			old := models.CveDetail{}
-			c.Nvd.CveID = c.CveID
 
 			// select old record.
 			result := tx.Where(&models.CveDetail{CveID: c.CveID}).First(&old)

--- a/db/redis.go
+++ b/db/redis.go
@@ -3,6 +3,11 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"time"
 
 	"github.com/cheggaaa/pb"
 	"github.com/go-redis/redis"
@@ -147,10 +152,15 @@ func (r *RedisDriver) GetByCpeName(cpeName string) (details []*models.CveDetail)
 }
 
 // InsertJvn insert items fetched from JVN.
-func (r *RedisDriver) InsertJvn(items []jvn.Item) error {
+func (r *RedisDriver) InsertJvn(items []jvn.Item, debugDiff bool) error {
 	log.Info("Inserting fetched CVEs...")
 
 	cves := convertJvn(items)
+	if debugDiff {
+		if err := r.getJvnDiff(cves); err != nil {
+			log.Warnf("Failed to create jvn diff. err : %s.", err)
+		}
+	}
 	if err := r.insertIntoJvn(cves); err != nil {
 		return err
 	}
@@ -170,7 +180,6 @@ func (r *RedisDriver) insertIntoJvn(cves []models.CveDetail) error {
 			bar.Increment()
 
 			var jj []byte
-			c.Jvn.CveID = c.CveID
 			if jj, err = json.Marshal(c.Jvn); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
@@ -216,10 +225,15 @@ func (r *RedisDriver) CountNvd() (int, error) {
 }
 
 // InsertNvd inserts CveInformation into DB
-func (r *RedisDriver) InsertNvd(entries []nvd.Entry) error {
+func (r *RedisDriver) InsertNvd(entries []nvd.Entry, debugDiff bool) error {
 	log.Info("Inserting CVEs...")
 
 	cves := convertNvd(entries)
+	if debugDiff {
+		if err := r.getNvdDiff(cves); err != nil {
+			log.Warnf("Failed to create nvd diff. err : %s.", err)
+		}
+	}
 	if err := r.insertIntoNvd(cves); err != nil {
 		return err
 	}
@@ -239,7 +253,6 @@ func (r *RedisDriver) insertIntoNvd(cves []models.CveDetail) error {
 			bar.Increment()
 
 			var jn []byte
-			c.Nvd.CveID = c.CveID
 			if jn, err = json.Marshal(c.Nvd); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
@@ -274,4 +287,220 @@ func (r *RedisDriver) insertIntoNvd(cves []models.CveDetail) error {
 	log.Infof("Refreshed %d Nvds.", len(refreshedNvds))
 	//  log.Debugf("%v", refreshedNvds)
 	return nil
+}
+
+// CveDiff is the defference of CVE
+type CveDiff struct {
+	CveID            string
+	Field            string
+	OldValue         string
+	NewValue         string
+	LastModifiedDate time.Time
+}
+
+func (r *RedisDriver) getJvnDiff(cves []models.CveDetail) (err error) {
+	var cveDiffs []*CveDiff
+	for _, cve := range cves {
+		var oldJvn models.Jvn
+		result := r.conn.HGet(hashKeyPrefix+cve.Jvn.CveID, "Jvn")
+		if result.Val() == "" {
+			continue
+		}
+
+		if err = json.Unmarshal([]byte(result.Val()), &oldJvn); err != nil {
+			log.Errorf("Failed to Unmarshal json. err : %s", err)
+			return err
+		}
+		if oldJvn.LastModifiedDate.Equal(cve.Jvn.LastModifiedDate) {
+			continue
+		}
+		if ok, cveDiff := getDiff(oldJvn.Title, cve.Jvn.Title); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "Title"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldJvn.Summary, cve.Jvn.Summary); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "Summary"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldJvn.JvnLink, cve.Jvn.JvnLink); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "JvnLink"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldJvn.JvnID, cve.Jvn.JvnID); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "JvnID"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		oldScoreStr := strconv.FormatFloat(oldJvn.Score, 'f', -1, 64)
+		newScoreStr := strconv.FormatFloat(cve.Jvn.Score, 'f', -1, 64)
+		if ok, cveDiff := getDiff(oldScoreStr, newScoreStr); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "Score"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldJvn.Severity, cve.Jvn.Severity); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "Severity"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldJvn.Vector, cve.Jvn.Vector); ok {
+			cveDiff.CveID = cve.Jvn.CveID
+			cveDiff.Field = "Vector"
+			cveDiff.LastModifiedDate = cve.Jvn.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if !reflect.DeepEqual(oldJvn.References, cve.Jvn.References) {
+			cveDiff := &CveDiff{
+				CveID:            cve.Jvn.CveID,
+				Field:            "References",
+				OldValue:         oldJvn.JvnLink,
+				NewValue:         cve.Jvn.JvnLink,
+				LastModifiedDate: cve.Jvn.LastModifiedDate,
+			}
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if !reflect.DeepEqual(oldJvn.Cpes, cve.Jvn.Cpes) {
+			cveDiff := &CveDiff{
+				CveID:            cve.Jvn.CveID,
+				Field:            "Cpes",
+				OldValue:         oldJvn.JvnLink,
+				NewValue:         cve.Jvn.JvnLink,
+				LastModifiedDate: cve.Jvn.LastModifiedDate,
+			}
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+	}
+	if 0 < len(cveDiffs) {
+		var cveDiffJSON []byte
+		if cveDiffJSON, err = json.Marshal(cveDiffs); err != nil {
+			log.Errorf("Failed to marshal diff. err: %s", err)
+		}
+		if err = ioutil.WriteFile("JvnDiff.json", cveDiffJSON, 0644); err != nil {
+			log.Errorf("Failed to write jvn diff json. err: %s", err)
+		}
+	}
+	log.Infof("%s Diffs", strconv.Itoa(len(cveDiffs)))
+	return err
+}
+
+func (r *RedisDriver) getNvdDiff(cves []models.CveDetail) (err error) {
+	var cveDiffs []*CveDiff
+	for _, cve := range cves {
+		var oldNvd models.Nvd
+		nvdLink := "https://nvd.nist.gov/vuln/detail/"
+		result := r.conn.HGet(hashKeyPrefix+cve.Nvd.CveID, "Nvd")
+		if result.Val() == "" {
+			continue
+		}
+
+		if err = json.Unmarshal([]byte(result.Val()), &oldNvd); err != nil {
+			log.Errorf("Failed to Unmarshal json. err : %s", err)
+			return err
+		}
+
+		if oldNvd.LastModifiedDate.Equal(cve.Nvd.LastModifiedDate) {
+			continue
+		}
+
+		if ok, cveDiff := getDiff(oldNvd.Summary, cve.Nvd.Summary); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "Summary"
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		oldScoreStr := strconv.FormatFloat(oldNvd.Score, 'f', -1, 64)
+		newScoreStr := strconv.FormatFloat(cve.Nvd.Score, 'f', -1, 64)
+		if ok, cveDiff := getDiff(oldScoreStr, newScoreStr); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "Score"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.AccessVector, cve.Nvd.AccessVector); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "AccessVector"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.AccessComplexity, cve.Nvd.AccessComplexity); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "AccessComplexity"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.Authentication, cve.Nvd.Authentication); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "Authentication"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.ConfidentialityImpact, cve.Nvd.ConfidentialityImpact); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "ConfidentialityImpact"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.AvailabilityImpact, cve.Nvd.AvailabilityImpact); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "AvailabilityImpact"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if ok, cveDiff := getDiff(oldNvd.CweID, cve.Nvd.CweID); ok {
+			cveDiff.CveID = cve.Nvd.CveID
+			cveDiff.Field = "CweID"
+			cveDiff.LastModifiedDate = cve.Nvd.LastModifiedDate
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if !reflect.DeepEqual(oldNvd.References, cve.Nvd.References) {
+			cveDiff := &CveDiff{
+				CveID:            cve.Nvd.CveID,
+				Field:            "References",
+				OldValue:         filepath.Join(nvdLink, cve.Nvd.CveID),
+				NewValue:         filepath.Join(nvdLink, cve.Nvd.CveID),
+				LastModifiedDate: cve.Nvd.LastModifiedDate,
+			}
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+		if !reflect.DeepEqual(oldNvd.Cpes, cve.Nvd.Cpes) {
+			cveDiff := &CveDiff{
+				CveID:            cve.Nvd.CveID,
+				Field:            "Cpes",
+				OldValue:         filepath.Join(nvdLink, cve.Nvd.CveID),
+				NewValue:         filepath.Join(nvdLink, cve.Nvd.CveID),
+				LastModifiedDate: cve.Nvd.LastModifiedDate,
+			}
+			cveDiffs = append(cveDiffs, cveDiff)
+		}
+	}
+	if 0 < len(cveDiffs) {
+		var cveDiffJSON []byte
+		if cveDiffJSON, err = json.Marshal(cveDiffs); err != nil {
+			log.Errorf("Failed to marshal diff. err: %s", err)
+		}
+		if err = ioutil.WriteFile("NvdDiff.json", cveDiffJSON, 0644); err != nil {
+			log.Errorf("Failed to write nvd diff json. err: %s", err)
+		}
+	}
+	log.Infof("%s Diffs", strconv.Itoa(len(cveDiffs)))
+	return err
+}
+
+func getDiff(oldValue, newValue string) (bool, *CveDiff) {
+	if oldValue == newValue {
+		return false, nil
+	}
+
+	return true, &CveDiff{
+		OldValue: oldValue,
+		NewValue: newValue,
+	}
 }

--- a/jvn/jvn.go
+++ b/jvn/jvn.go
@@ -1,16 +1,21 @@
 package jvn
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cheggaaa/pb"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/util"
-	"github.com/parnurzeal/gorequest"
 )
 
 type rdf struct {
@@ -97,31 +102,51 @@ func fetchJvnConcurrently(urls []string) (allItems []Item, err error) {
 	defer close(resChan)
 	defer close(errChan)
 
+	for _, url := range urls {
+		log.Infof("Fetching... %s", url)
+	}
+
+	var pool *pb.Pool
+	bars := map[string]*pb.ProgressBar{}
 	go func() {
 		for _, url := range urls {
+			prefix := filepath.Base(url) + ":"
+			bars[url] = pb.New(util.GetFileSize(url)).SetUnits(pb.U_BYTES).Prefix(prefix)
+
+			if pool == nil {
+				if pool, err = pb.StartPool(bars[url]); err != nil {
+					log.Warn(err)
+				}
+			} else {
+				pool.Add(bars[url])
+			}
 			reqChan <- url
 		}
 	}()
 
 	concurrency := len(urls)
 	tasks := util.GenWorkers(concurrency)
+	wg := new(sync.WaitGroup)
 	for range urls {
+		wg.Add(1)
 		tasks <- func() {
 			select {
 			case url := <-reqChan:
-				log.Infof("Fetching... %s", url)
-				items, err := fetchJvn(url)
+				items, err := fetchJvn(url, bars[url])
+				wg.Done()
 				if err != nil {
 					errChan <- err
 					return
 				}
 				resChan <- items
 			}
+			return
 		}
 	}
+	wg.Wait()
+	pool.Stop()
 
 	errs := []error{}
-	bar := pb.StartNew(len(urls))
 	timeout := time.After(10 * 60 * time.Second)
 	for range urls {
 		select {
@@ -132,32 +157,48 @@ func fetchJvnConcurrently(urls []string) (allItems []Item, err error) {
 		case <-timeout:
 			return allItems, fmt.Errorf("Timeout Fetching Jvn")
 		}
-		bar.Increment()
 	}
-	bar.Finish()
-	//  bar.FinishPrint("Finished to fetch CVE information from JVN.")
 	if 0 < len(errs) {
 		return allItems, fmt.Errorf("%s", errs)
 	}
 	return allItems, nil
 }
 
-func fetchJvn(url string) (items []Item, err error) {
-	var body string
+func fetchJvn(targetURL string, bar *pb.ProgressBar) (items []Item, err error) {
 	var errs []error
+	var proxyURL *url.URL
 	var resp *http.Response
 
-	resp, body, errs = gorequest.New().Proxy(c.Conf.HTTPProxy).Get(url).End()
+	httpCilent := &http.Client{}
+	if c.Conf.HTTPProxy != "" {
+		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
+			return nil, fmt.Errorf("Failed to parse proxy url: %s", err)
+		}
+		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	}
+
+	if resp, err = httpCilent.Get(targetURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Download failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	buf := bytes.NewBuffer(nil)
+	bar.Start()
+	rd := bar.NewProxyReader(resp.Body)
+	io.Copy(buf, rd)
+
 	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
 		return items, fmt.Errorf(
-			"HTTP error. errs: %v, url: %s", errs, url)
+			"HTTP error. errs: %v, url: %s", errs, targetURL)
 	}
 
 	var rdf rdf
-	if err = xml.Unmarshal([]byte(body), &rdf); err != nil {
+	if err = xml.Unmarshal(buf.Bytes(), &rdf); err != nil {
 		return items, fmt.Errorf(
-			"Failed to unmarshal. url: %s, err: %s", url, err)
+			"Failed to unmarshal. url: %s, err: %s", targetURL, err)
 	}
 	items = append(items, rdf.Items...)
+	bar.Finish()
 	return
 }

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -5,15 +5,19 @@ import (
 	"compress/gzip"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cheggaaa/pb"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/util"
-	"github.com/parnurzeal/gorequest"
 )
 
 // Nvd is array of Entry
@@ -95,31 +99,51 @@ func fetchFeedFileConcurrently(urls []string) (nvds []Nvd, err error) {
 	defer close(resChan)
 	defer close(errChan)
 
+	for _, url := range urls {
+		log.Infof("Fetching... %s", url)
+	}
+
+	var pool *pb.Pool
+	bars := map[string]*pb.ProgressBar{}
 	go func() {
 		for _, url := range urls {
+			prefix := filepath.Base(url) + ":"
+			bars[url] = pb.New(util.GetFileSize(url)).SetUnits(pb.U_BYTES).Prefix(prefix)
+
+			if pool == nil {
+				if pool, err = pb.StartPool(bars[url]); err != nil {
+					log.Warn(err)
+				}
+			} else {
+				pool.Add(bars[url])
+			}
 			reqChan <- url
 		}
 	}()
 
 	concurrency := len(urls)
 	tasks := util.GenWorkers(concurrency)
+	wg := new(sync.WaitGroup)
 	for range urls {
+		wg.Add(1)
 		tasks <- func() {
 			select {
 			case url := <-reqChan:
-				log.Infof("Fetching... %s", url)
-				nvd, err := fetchFeedFile(url)
+				nvd, err := fetchFeedFile(url, bars[url])
+				wg.Done()
 				if err != nil {
 					errChan <- err
 					return
 				}
 				resChan <- nvd
 			}
+			return
 		}
 	}
+	wg.Wait()
+	pool.Stop()
 
 	errs := []error{}
-	bar := pb.StartNew(len(urls))
 	timeout := time.After(10 * 60 * time.Second)
 	for range urls {
 		select {
@@ -130,45 +154,58 @@ func fetchFeedFileConcurrently(urls []string) (nvds []Nvd, err error) {
 		case <-timeout:
 			return nvds, fmt.Errorf("Timeout Fetching Nvd")
 		}
-		bar.Increment()
 	}
-	bar.Finish()
-	//  bar.FinishPrint("Finished to fetch CVE information from JVN.")
 	if 0 < len(errs) {
 		return nvds, fmt.Errorf("%s", errs)
 	}
 	return nvds, nil
 }
 
-func fetchFeedFile(url string) (nvd Nvd, err error) {
-	var body string
+func fetchFeedFile(targetURL string, bar *pb.ProgressBar) (nvd Nvd, err error) {
 	var errs []error
+	var proxyURL *url.URL
 	var resp *http.Response
 
-	resp, body, errs = gorequest.New().Proxy(c.Conf.HTTPProxy).Get(url).End()
-	//  defer resp.Body.Close()
-	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
-		return nvd, fmt.Errorf(
-			"HTTP error. errs: %v, url: %s", errs, url)
+	httpCilent := &http.Client{}
+	if c.Conf.HTTPProxy != "" {
+		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
+			return nvd, fmt.Errorf("Failed to parse proxy url: %s", err)
+		}
+		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
 	}
 
-	b := bytes.NewBufferString(body)
-	reader, err := gzip.NewReader(b)
+	if resp, err = httpCilent.Get(targetURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Download failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	buf := bytes.NewBuffer(nil)
+	bar.Start()
+	rd := bar.NewProxyReader(resp.Body)
+	io.Copy(buf, rd)
+
+	if len(errs) > 0 || resp == nil || resp.StatusCode != 200 {
+		return nvd, fmt.Errorf(
+			"HTTP error. errs: %v, url: %s", errs, targetURL)
+	}
+
+	reader, err := gzip.NewReader(buf)
 	defer reader.Close()
 	if err != nil {
 		return nvd, fmt.Errorf(
-			"Failed to decompress NVD feedfile. url: %s, err: %s", url, err)
+			"Failed to decompress NVD feedfile. url: %s, err: %s", targetURL, err)
 	}
 
 	bytes, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nvd, fmt.Errorf(
-			"Failed to Read NVD feedfile. url: %s, err: %s", url, err)
+			"Failed to Read NVD feedfile. url: %s, err: %s", targetURL, err)
 	}
 
 	if err = xml.Unmarshal(bytes, &nvd); err != nil {
 		return nvd, fmt.Errorf(
-			"Failed to unmarshal. url: %s, err: %s", url, err)
+			"Failed to unmarshal. url: %s, err: %s", targetURL, err)
 	}
 	return nvd, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,14 @@
 package util
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	c "github.com/kotakanbe/go-cve-dictionary/config"
+	log "github.com/kotakanbe/go-cve-dictionary/log"
 )
 
 // GenWorkers generate workders
@@ -26,4 +31,35 @@ func GetDefaultLogDir() string {
 		defaultLogDir = filepath.Join(os.Getenv("APPDATA"), "vuls")
 	}
 	return defaultLogDir
+}
+
+// GetFileSize returns download size
+func GetFileSize(targetURL string) int {
+	var proxyURL *url.URL
+	var resp *http.Response
+	var err error
+
+	httpCilent := &http.Client{}
+	if c.Conf.HTTPProxy != "" {
+		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
+			return 0
+		}
+		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	}
+
+	if resp, err = httpCilent.Head(targetURL); err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Accept-Ranges") != "bytes" {
+		log.Warn("Not supported range access.")
+	}
+
+	// the value -1 indicates that the length is unknown.
+	if resp.ContentLength <= 0 {
+		log.Info("Failed to get content length.")
+		return 0
+	}
+	return int(resp.ContentLength)
 }


### PR DESCRIPTION
add -debug-diff only when using redis backend.
and change http get method for displaying  the better progress bar.

You can test it as below.

- prepare the redis server having old cve data.
- execute `go-cve-dictionary` with `-debug-diff` option.

```
$ go-cve-dictionary  fetchjvn  -debug-diff  -dbtype redis -dbpath "redis://localhost/0" -years 2008
$ go-cve-dictionary  fetchnvd  -debug-diff  -dbtype redis -dbpath "redis://localhost/0" -years 2008
```

- check diff files.

```
$ ls JvnDiff.json NvdDiff.json

JvnDiff.json NvdDiff.json
```

- cat NvdDiff.json

```
.......................
  {
    CveID: CVE-2014-8127,
    Field: Score,
    OldValue: 0,
    NewValue: 4.3
  },
  {
    CveID: CVE-2014-8127,
    Field: AccessVector,
    OldValue: "",
    NewValue: NETWORK
  },
  {
    CveID: CVE-2014-8127,
    Field: AccessComplexity,
    OldValue: "",
    NewValue: MEDIUM
  },
  {
    CveID: CVE-2014-8127,
    Field: Authentication,
    OldValue: "",
    NewValue: NONE
  },
  {
    CveID: CVE-2014-8127,
    Field: ConfidentialityImpact,
    OldValue: "",
    NewValue: NONE
  },
  {
    CveID: CVE-2014-8127,
    Field: AvailabilityImpact,
    OldValue: "",
    NewValue: PARTIAL
  },
  {
    CveID: CVE-2014-8127,
    Field: CweID,
    OldValue: "",
    NewValue: CWE-125
  },
  {
    "CveID": "CVE-2014-8127",
    Field: References,
    OldValue: https:/nvd.nist.gov/vuln/detail/CVE-2014-8127,
    NewValue: https:/nvd.nist.gov/vuln/detail/CVE-2014-8127
.......................
```
