### PR TITLE
add quiet option and args environment for AWS Lambda

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -184,6 +184,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "107b8778e8e56469493bbde2903e5090608357e5ee3b1c2341fed7e008534280"
+  inputs-digest = "1de649184a55285191648df90e6d5701663a2ec148a9206681590e18c731784a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -273,8 +273,6 @@ For the first time, run the blow command to fetch data for entire period. (It ta
         Refresh NVD data in the last two years.
   -quiet
         quiet mode (no output)
-  -quiet
-        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -years

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ fetchnvd:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
@@ -270,6 +271,10 @@ For the first time, run the blow command to fetch data for entire period. (It ta
         http://proxy-url:port (default: empty)
   -last2y
         Refresh NVD data in the last two years.
+  -quiet
+        quiet mode (no output)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -years
@@ -310,6 +315,7 @@ fetchjvn:
                 [-http-proxy=http://192.168.0.1:8080]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
   -dbpath string
@@ -326,6 +332,8 @@ fetchjvn:
         Refresh JVN data in the last two years.
   -latest
         Refresh JVN data for latest.
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -years
@@ -371,6 +379,7 @@ server:
                 [-dbtype=mysql|postgres|sqlite3|redis]
                 [-debug]
                 [-debug-sql]
+                [-quiet]
                 [-log-dir=/path/to/log]
 
   -bind string
@@ -383,6 +392,8 @@ server:
         debug mode (default: false)
   -debug-sql
         SQL debug mode (default: false)
+  -quiet
+        quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
   -port string

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -19,6 +20,7 @@ import (
 type FetchJvnCmd struct {
 	debug    bool
 	debugSQL bool
+	quiet    bool
 	logDir   string
 
 	dbpath   string
@@ -50,6 +52,7 @@ func (*FetchJvnCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 `
@@ -57,10 +60,9 @@ func (*FetchJvnCmd) Usage() string {
 
 // SetFlags set flag
 func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.debug, "debug", false,
-		"debug mode")
-	f.BoolVar(&p.debugSQL, "debug-sql", false,
-		"SQL debug mode")
+	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -91,7 +93,12 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.logDir)
+	c.Conf.Quiet = p.quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.logDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.logDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.Debug = p.debug

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -19,6 +20,7 @@ import (
 type FetchNvdCmd struct {
 	debug    bool
 	debugSQL bool
+	quiet    bool
 	logDir   string
 
 	dbpath string
@@ -47,6 +49,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
@@ -57,10 +60,9 @@ For the first time, run the blow command to fetch data for entire period. (It ta
 
 // SetFlags set flag
 func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.debug, "debug", false,
-		"debug mode")
-	f.BoolVar(&p.debugSQL, "debug-sql", false,
-		"SQL debug mode")
+	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode")
+	f.BoolVar(&p.quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -88,7 +90,12 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.logDir)
+	c.Conf.Quiet = p.quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.logDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.logDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.Debug = p.debug

--- a/commands/server.go
+++ b/commands/server.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"flag"
+	"io/ioutil"
 	"os"
 
 	"github.com/google/subcommands"
@@ -17,6 +18,7 @@ import (
 type ServerCmd struct {
 	debug    bool
 	debugSQL bool
+	quiet    bool
 	logDir   string
 
 	dbpath string
@@ -41,6 +43,7 @@ func (*ServerCmd) Usage() string {
 		[-dbtype=mysql|postgres|sqlite3|redis]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-log-dir=/path/to/log]
 
 `
@@ -48,10 +51,9 @@ func (*ServerCmd) Usage() string {
 
 // SetFlags set flag
 func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
-	f.BoolVar(&p.debug, "debug", false,
-		"debug mode (default: false)")
-	f.BoolVar(&p.debugSQL, "debug-sql", false,
-		"SQL debug mode (default: false)")
+	f.BoolVar(&p.debug, "debug", false, "debug mode (default: false)")
+	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode (default: false)")
+	f.BoolVar(&p.quiet, "quiet", false, "quiet mode (no output)")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
@@ -73,7 +75,12 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	log.Initialize(p.logDir)
+	c.Conf.Quiet = p.quiet
+	if c.Conf.Quiet {
+		log.Initialize(p.logDir, ioutil.Discard)
+	} else {
+		log.Initialize(p.logDir, os.Stderr)
+	}
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.Debug = p.debug

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ var Conf Config
 type Config struct {
 	Debug    bool
 	DebugSQL bool
+	Quiet    bool
 
 	DumpPath string
 	DBPath   string

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -2,10 +2,13 @@ package db
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/cheggaaa/pb"
 	"github.com/jinzhu/gorm"
 	"github.com/k0kubun/pp"
+	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/jvn"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
@@ -201,7 +204,13 @@ func (r *RDBDriver) InsertJvn(items []jvn.Item) error {
 func (r *RDBDriver) insertIntoJvn(cves []models.CveDetail) error {
 	var err error
 	var refreshedJvns []string
-	bar := pb.StartNew(len(cves))
+	bar := pb.New(len(cves))
+	if c.Conf.Quiet {
+		bar.Output = ioutil.Discard
+	} else {
+		bar.Output = os.Stderr
+	}
+	bar.Start()
 
 	for chunked := range chunkSlice(cves, 10) {
 		var tx *gorm.DB

--- a/db/redis.go
+++ b/db/redis.go
@@ -3,9 +3,12 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/cheggaaa/pb"
 	"github.com/go-redis/redis"
+	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/jvn"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
@@ -161,7 +164,13 @@ func (r *RedisDriver) InsertJvn(items []jvn.Item) error {
 func (r *RedisDriver) insertIntoJvn(cves []models.CveDetail) error {
 	var err error
 	var refreshedJvns []string
-	bar := pb.StartNew(len(cves))
+	bar := pb.New(len(cves))
+	if c.Conf.Quiet {
+		bar.Output = ioutil.Discard
+	} else {
+		bar.Output = os.Stderr
+	}
+	bar.Start()
 
 	for chunked := range chunkSlice(cves, 10) {
 		var pipe redis.Pipeliner

--- a/jvn/jvn.go
+++ b/jvn/jvn.go
@@ -3,7 +3,9 @@ package jvn
 import (
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/cheggaaa/pb"
@@ -121,7 +123,13 @@ func fetchJvnConcurrently(urls []string) (allItems []Item, err error) {
 	}
 
 	errs := []error{}
-	bar := pb.StartNew(len(urls))
+	bar := pb.New(len(urls))
+	if c.Conf.Quiet {
+		bar.Output = ioutil.Discard
+	} else {
+		bar.Output = os.Stderr
+	}
+	bar.Start()
 	timeout := time.After(10 * 60 * time.Second)
 	for range urls {
 		select {

--- a/log/log.go
+++ b/log/log.go
@@ -1,22 +1,41 @@
 package log
 
 import (
+	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/k0kubun/pp"
 	formatter "github.com/kotakanbe/logrus-prefixed-formatter"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/rifflock/lfshook"
 	"github.com/sirupsen/logrus"
 )
 
-var logger *logrus.Entry
+var (
+	logger              *logrus.Entry
+	logrusDefaultOutput = os.Stderr
+	ppDefaultOutput     = colorable.NewColorableStderr()
+)
 
-// Initialize logger
-func Initialize(logDir string) {
+func init() {
 	log := logrus.New()
 	log.Formatter = &formatter.TextFormatter{}
-	log.Out = os.Stderr
+	log.Out = ioutil.Discard
 	log.Level = logrus.InfoLevel
+	fields := logrus.Fields{"prefix": ""}
+	logger = log.WithFields(fields)
+}
+
+// Initialize logger
+func Initialize(logDir string, output ...io.Writer) {
+	logger.Logger.Out = logrusDefaultOutput
+	pp.SetDefaultOutput(ppDefaultOutput)
+	if 0 < len(output) {
+		logger.Logger.Out = output[0]
+		pp.SetDefaultOutput(output[0])
+	}
 
 	// File output
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
@@ -27,7 +46,7 @@ func Initialize(logDir string) {
 
 	if _, err := os.Stat(logDir); err == nil {
 		path := filepath.Join(logDir, "cve-dictionary.log")
-		log.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
+		logger.Logger.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
 			logrus.DebugLevel: path,
 			logrus.InfoLevel:  path,
 			logrus.WarnLevel:  path,
@@ -36,9 +55,6 @@ func Initialize(logDir string) {
 			logrus.PanicLevel: path,
 		}))
 	}
-
-	fields := logrus.Fields{"prefix": ""}
-	logger = log.WithFields(fields)
 }
 
 // SetDebug set debug level

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/subcommands"
 	"github.com/kotakanbe/go-cve-dictionary/commands"
@@ -29,7 +30,11 @@ func main() {
 
 	var v = flag.Bool("v", false, "Show version")
 
-	flag.Parse()
+	if envArgs := os.Getenv("GO_CVE_DICTIONARY_ARGS"); 0 < len(envArgs) {
+		flag.CommandLine.Parse(strings.Fields(envArgs))
+	} else {
+		flag.Parse()
+	}
 
 	if *v {
 		fmt.Printf("go-cve-dictionary %s %s\n", version, revision)

--- a/nvd/nvd.go
+++ b/nvd/nvd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/cheggaaa/pb"
@@ -119,7 +120,13 @@ func fetchFeedFileConcurrently(urls []string) (nvds []Nvd, err error) {
 	}
 
 	errs := []error{}
-	bar := pb.StartNew(len(urls))
+	bar := pb.New(len(urls))
+	if c.Conf.Quiet {
+		bar.Output = ioutil.Discard
+	} else {
+		bar.Output = os.Stderr
+	}
+	bar.Start()
 	timeout := time.After(10 * 60 * time.Second)
 	for range urls {
 		select {


### PR DESCRIPTION
1. add quiet option
2. change all output to stderr
3. add args environment
4. no output if not execute log.Initialize 
(when we used go-cve-dictionary's method without log.Initialize, panic occured.)