### PR TITLE
fix: Insert JVN entries which have multiple CVE-IDs in references

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -66,6 +66,7 @@ func convertNvd(entries []nvd.Entry) (cves []models.CveDetail) {
 		cve := models.CveDetail{
 			CveID: entry.CveID,
 			Nvd: models.Nvd{
+				CveID:                 entry.CveID,
 				Summary:               entry.Summary,
 				Score:                 stringToFloat(entry.Cvss.Score),
 				AccessVector:          entry.Cvss.AccessVector,
@@ -125,46 +126,41 @@ func convertJvn(items []jvn.Item) (cves []models.CveDetail) {
 			panic(err)
 		}
 
-		var cveIDs []string
-		var cveID string
-		cveIDs = getCveIDs(item)
+		cveIDs := getCveIDs(item)
 		if len(cveIDs) == 0 {
 			log.Debugf("No CveIDs in references. JvnID: %s, Link: %s",
 				item.Identifier, item.Link)
 			// ignore this item
 			continue
 
-		} else if 1 < len(cveIDs) {
-			log.Debugf("Some CveIDs in references. JvnID: %s, Link: %s, CveIDs: %v",
-				item.Identifier, item.Link, cveIDs)
-			// TODO ignore this item??
-			continue
 		}
-		cveID = cveIDs[0]
 
-		cve := models.CveDetail{
-			CveID: cveID,
+		for _, cveID := range cveIDs {
+			cve := models.CveDetail{
+				CveID: cveID,
 
-			// JVN
-			Jvn: models.Jvn{
-				Title:   strings.Replace(item.Title, "\r", "", -1),
-				Summary: strings.Replace(item.Description, "\r", "", -1),
-				JvnLink: item.Link,
-				JvnID:   item.Identifier,
+				// JVN
+				Jvn: models.Jvn{
+					Title:   strings.Replace(item.Title, "\r", "", -1),
+					Summary: strings.Replace(item.Description, "\r", "", -1),
+					JvnLink: item.Link,
+					JvnID:   item.Identifier,
+					CveID:   cveID,
 
-				Score:    stringToFloat(item.Cvss.Score),
-				Severity: item.Cvss.Severity,
-				Vector:   item.Cvss.Vector,
-				//  Version:  item.Cvss.Version,
+					Score:    stringToFloat(item.Cvss.Score),
+					Severity: item.Cvss.Severity,
+					Vector:   item.Cvss.Vector,
+					//  Version:  item.Cvss.Version,
 
-				References: refs,
-				Cpes:       cpes,
+					References: refs,
+					Cpes:       cpes,
 
-				PublishedDate:    publish,
-				LastModifiedDate: modified,
-			},
+					PublishedDate:    publish,
+					LastModifiedDate: modified,
+				},
+			}
+			cves = append(cves, cve)
 		}
-		cves = append(cves, cve)
 	}
 	return
 }


### PR DESCRIPTION
Fix a bug that did not insert an entry with multiple CVE-IDs in JVN>references