### PR TITLE
Add goreleaser to distribute binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ go-cve-dictionary
 *.sqlite3-shm
 *.sqlite3-wal
 tags
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,23 @@
+project_name: go-cve-dictionary
+release:
+  github:
+    owner: kotakanbe
+    name: go-cve-dictionary
+builds:
+- goos:
+  - linux
+  goarch:
+  - amd64
+  main: .
+  ldflags: -s -w -X main.version={{.Version}} -X main.revision={{.Commit}}
+  binary: go-cve-dictionary
+archive:
+  format: tar.gz
+  name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+    .Arm }}{{ end }}'
+  files:
+  - LICENSE
+  - README*
+  - CHANGELOG.md
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - 1.x
+
+after_success:
+  - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash


### PR DESCRIPTION
After Travis is configured with the GitHub token, this will automatically publish binaries.

See https://github.com/future-architect/vuls/pull/460 and https://github.com/kotakanbe/go-cve-dictionary/pull/75#issuecomment-377140104