### PR TITLE
add log-json option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ fetchnvd:
                 [-debug-sql]
                 [-quiet]
                 [-log-dir=/path/to/log]
+                [-log-json]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in `seq 2002 $(date +"%Y")`; do go-cve-dictionary fetchnvd -years $i ; done
@@ -282,6 +283,8 @@ For the first time, run the blow command to fetch data for entire period. (It ta
         quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
+  -log-json
+        output log as JSON
 ```
 
 - Fetch data for entire period.
@@ -328,6 +331,7 @@ fetchjvn:
                 [-debug-sql]
                 [-quiet]
                 [-log-dir=/path/to/log]
+                [-log-json]
 
   -dbpath string
         /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
@@ -347,6 +351,8 @@ fetchjvn:
         quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
+  -log-json
+        output log as JSON
   -years
         Refresh JVN data of specific years.
 
@@ -392,6 +398,7 @@ server:
                 [-debug-sql]
                 [-quiet]
                 [-log-dir=/path/to/log]
+                [-log-json]
 
   -bind string
         HTTP server bind to IP address (default: loop back interface) (default "127.0.0.1")
@@ -407,6 +414,8 @@ server:
         quiet mode (no output)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
+  -log-json
+        output log as JSON
   -port string
         HTTP server port number (default: 1323) (default "1323")
 

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -22,6 +22,7 @@ type FetchJvnCmd struct {
 	debugSQL bool
 	quiet    bool
 	logDir   string
+	logJSON  bool
 
 	dbpath   string
 	dbtype   string
@@ -54,6 +55,7 @@ func (*FetchJvnCmd) Usage() string {
 		[-debug-sql]
 		[-quiet]
 		[-log-dir=/path/to/log]
+		[-log-json]
 
 `
 }
@@ -66,6 +68,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.logJSON, "log-json", false, "output log as JSON")
 
 	pwd := os.Getenv("PWD")
 	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
@@ -101,7 +104,7 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	//  c.Conf.DumpPath = p.dumpPath
 	c.Conf.HTTPProxy = p.httpProxy
 
-	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug)
+	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug, p.logJSON)
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError
 	}

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -24,6 +24,7 @@ type FetchNvdCmd struct {
 	debugSQL bool
 	quiet    bool
 	logDir   string
+	logJSON  bool
 
 	dbpath string
 	dbtype string
@@ -58,6 +59,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-quiet]
 		[-xml]
 		[-log-dir=/path/to/log]
+		[-log-json]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in ` + "`seq 2002 $(date +\"%Y\")`;" + ` do go-cve-dictionary fetchnvd -years $i; done
@@ -73,6 +75,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.logJSON, "log-json", false, "ouput log as JSON")
 
 	pwd := os.Getenv("PWD")
 	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
@@ -105,7 +108,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	c.Conf.Debug = p.debug
 	c.Conf.Quiet = p.quiet
-	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug)
+	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug, p.logJSON)
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.DBPath = p.dbpath

--- a/commands/list.go
+++ b/commands/list.go
@@ -23,6 +23,7 @@ type ListCmd struct {
 	debug     bool
 	debugSQL  bool
 	logDir    string
+	logJSON   bool
 	dbpath    string
 	dbtype    string
 	httpProxy string
@@ -44,6 +45,7 @@ func (*ListCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-log-dir=/path/to/log]
+		[-log-json]
 `
 }
 
@@ -54,6 +56,7 @@ func (p *ListCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.logJSON, "log-json", false, "output log as JSON")
 
 	pwd := os.Getenv("PWD")
 	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
@@ -77,7 +80,7 @@ func (p *ListCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	c.Conf.DBPath = p.dbpath
 	c.Conf.DBType = p.dbtype
 	c.Conf.HTTPProxy = p.httpProxy
-	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug)
+	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug, p.logJSON)
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError
 	}

--- a/commands/server.go
+++ b/commands/server.go
@@ -19,6 +19,7 @@ type ServerCmd struct {
 	debugSQL bool
 	quiet    bool
 	logDir   string
+	logJSON  bool
 
 	dbpath string
 	dbtype string
@@ -44,6 +45,7 @@ func (*ServerCmd) Usage() string {
 		[-debug-sql]
 		[-quiet]
 		[-log-dir=/path/to/log]
+		[-log-json]
 
 `
 }
@@ -56,6 +58,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+	f.BoolVar(&p.logJSON, "log-json", false, "output log as JSON")
 
 	pwd := os.Getenv("PWD")
 	f.StringVar(&p.dbpath, "dbpath", pwd+"/cve.sqlite3",
@@ -76,7 +79,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	c.Conf.Debug = p.debug
 	c.Conf.Quiet = p.quiet
-	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug)
+	log.SetLogger(p.logDir, c.Conf.Quiet, c.Conf.Debug, p.logJSON)
 
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.Bind = p.bind

--- a/log/log.go
+++ b/log/log.go
@@ -11,10 +11,17 @@ import (
 )
 
 // SetLogger set logger
-func SetLogger(logDir string, quiet, debug bool) {
-	lvlHundler := logger.LvlFilterHandler(logger.LvlInfo, logger.StderrHandler)
+func SetLogger(logDir string, quiet, debug, logJSON bool) {
+	stderrHundler := logger.StderrHandler
+	logFormat := logger.LogfmtFormat()
+	if logJSON {
+		logFormat = logger.JsonFormatEx(false, true)
+		stderrHundler = logger.StreamHandler(os.Stderr, logFormat)
+	}
+
+	lvlHundler := logger.LvlFilterHandler(logger.LvlInfo, stderrHundler)
 	if debug {
-		lvlHundler = logger.LvlFilterHandler(logger.LvlDebug, logger.StdoutHandler)
+		lvlHundler = logger.LvlFilterHandler(logger.LvlDebug, stderrHundler)
 	}
 	if quiet {
 		lvlHundler = logger.LvlFilterHandler(logger.LvlDebug, logger.DiscardHandler())
@@ -30,7 +37,7 @@ func SetLogger(logDir string, quiet, debug bool) {
 	if _, err := os.Stat(logDir); err == nil {
 		logPath := filepath.Join(logDir, "cve-dictionary.log")
 		hundler = logger.MultiHandler(
-			logger.Must.FileHandler(logPath, logger.LogfmtFormat()),
+			logger.Must.FileHandler(logPath, logFormat),
 			lvlHundler,
 		)
 	} else {


### PR DESCRIPTION
add  log-json option

# Usage

`go-cve-dictionary fetchjvn -last2y -log-json`

# Output

- stderr

```
{"lvl":"info","msg":"Fetching... https://jvndb.jvn.jp/ja/feed/checksum.txt","t":"2018-04-26T13:59:13.833838266+09:00"}
{"lvl":"info","msg":"Up to date: https://jvndb.jvn.jp/ja/rss/years/jvndb_2018.rdf","t":"2018-04-26T13:59:14.308656273+09:00"}
{"lvl":"info","msg":"Up to date: https://jvndb.jvn.jp/ja/rss/years/jvndb_2017.rdf","t":"2018-04-26T13:59:14.308785301+09:00"}
{"lvl":"info","msg":"Up to date: https://jvndb.jvn.jp/ja/rss/jvndb.rdf","t":"2018-04-26T13:59:14.30883456+09:00"}
{"lvl":"info","msg":"Up to date: https://jvndb.jvn.jp/ja/rss/jvndb_new.rdf","t":"2018-04-26T13:59:14.308876084+09:00"}
{"lvl":"info","msg":"Already up to date","t":"2018-04-26T13:59:14.308917585+09:00"}
```

- logfile

```
{"lvl":"dbug","msg":"Opening DB (sqlite3).","t":"2018-04-26T13:53:32.636510054+09:00"}
{"lvl":"dbug","msg":"Migrating DB (sqlite3).","t":"2018-04-26T13:53:32.640851216+09:00"}
{"lvl":"info","msg":"Fetching... https://jvndb.jvn.jp/ja/feed/checksum.txt","t":"2018-04-26T13:53:32.667991695+09:00"}
{"lvl":"dbug","msg":"Opening DB (sqlite3).","t":"2018-04-26T13:53:43.775429022+09:00"}
{"lvl":"dbug","msg":"Migrating DB (sqlite3).","t":"2018-04-26T13:53:43.778884868+09:00"}
```