### PR TITLE
fix(rdb): use tx instead of r.conn

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -788,7 +788,7 @@ func (r *RDBDriver) InsertNvdJSON(cves []models.CveDetail) (err error) {
 			if !result.RecordNotFound() {
 				// select NvdJSON from db
 				json := models.NvdJSON{}
-				err = r.conn.Model(&old).Related(&json, "NvdJSON").Error
+				err = tx.Model(&old).Related(&json, "NvdJSON").Error
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}


### PR DESCRIPTION
# Bug fix

I got the following error on `nvd-json` branch.
```
EROR[07-03|18:25:17] Failed to insert. dbpath: ~/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3, err: database is locked
```

In the transaction, `tx` should be used.