### PR TITLE
fix(fetchnvd): change NVD feed URL #99

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -165,6 +165,11 @@ func (p *FetchJvnCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 		return subcommands.ExitFailure
 	}
 
+	if len(metas) == 0 {
+		log.Errorf("No meta files fetched")
+		return subcommands.ExitFailure
+	}
+
 	//TODO use meta.Status()
 	needUpdates := []models.FeedMeta{}
 	for _, m := range metas {

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -155,7 +155,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 		}
 		years = append(years, c.Latest)
 	default:
-		log.Errorf("specify -last2y, -modified or -years")
+		log.Errorf("specify -last2y, -latest or -years")
 		return subcommands.ExitUsageError
 	}
 
@@ -173,6 +173,11 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	metas, err := nvd.FetchLatestFeedMeta(driver, years, c.Conf.NVDXML)
 	if err != nil {
 		log.Errorf("%s", err)
+		return subcommands.ExitFailure
+	}
+
+	if len(metas) == 0 {
+		log.Errorf("No meta files fetched")
 		return subcommands.ExitFailure
 	}
 

--- a/fetcher/nvd/util.go
+++ b/fetcher/nvd/util.go
@@ -151,10 +151,10 @@ func MakeNvdMetaURLs(year int, xml bool) (url []string) {
 	formatTemplate := ""
 	if xml {
 		// https://nvd.nist.gov/vuln/data-feeds#XML_FEED
-		formatTemplate = "https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.meta"
+		formatTemplate = "https://nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.meta"
 	} else {
 		// https: //nvd.nist.gov/vuln/data-feeds#JSON_FEED
-		formatTemplate = "https://static.nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%s.meta"
+		formatTemplate = "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%s.meta"
 	}
 
 	if year == c.Latest {


### PR DESCRIPTION
Bug fix #99 

URL of NVD feed was chagned.
Everyone have to update to the latest version of go-cve-dictionary.
If you do not update go-cve-dictionary, you can not update NVD feed.
