### PR TITLE
fix(db): chagne RDB column type to text

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -147,7 +147,6 @@ func (f FeedMeta) ToTableWriterRow() []string {
 // CveDetail is a parent of Jnv/Nvd model
 type CveDetail struct {
 	gorm.Model `json:"-" xml:"-"`
-	CveInfoID  uint `json:"-" xml:"-"`
 
 	CveID   string
 	NvdXML  *NvdXML  `json:",omitempty"`
@@ -161,7 +160,7 @@ type NvdXML struct {
 	CveDetailID uint `json:"-" xml:"-"`
 
 	CveID   string
-	Summary string `gorm:"size:4096"`
+	Summary string `sql:"type:text"`
 
 	Cvss2      Cvss2
 	Cpes       []Cpe `json:",omitempty"`
@@ -204,7 +203,7 @@ type Jvn struct {
 
 	CveID   string
 	Title   string
-	Summary string `gorm:"size:8192"`
+	Summary string `sql:"type:text"`
 	JvnLink string
 	JvnID   string
 
@@ -255,7 +254,7 @@ type EnvCpe struct {
 type CpeBase struct {
 	URI             string
 	FormattedString string
-	WellFormedName  string
+	WellFormedName  string `sql:"type:text"`
 	CpeWFN
 
 	VersionStartExcluding string
@@ -288,7 +287,7 @@ type Reference struct {
 	JvnID      uint `json:"-" xml:"-"`
 
 	Source string
-	Link   string `gorm:"size:512"`
+	Link   string `sql:"type:text"`
 }
 
 // Affect has vendor/product/version info in NVD JSON
@@ -331,8 +330,7 @@ type Cvss2 struct {
 	NvdXMLID   uint `json:"-" xml:"-"`
 	JvnID      uint `json:"-" xml:"-"`
 
-	VectorString string
-
+	VectorString          string
 	AccessVector          string
 	AccessComplexity      string
 	Authentication        string
@@ -350,7 +348,6 @@ type Cvss2Extra struct {
 	NvdJSONID uint `json:"-" xml:"-"`
 
 	Cvss2
-
 	ExploitabilityScore     float64
 	ImpactScore             float64
 	ObtainAllPrivilege      bool
@@ -365,5 +362,5 @@ type Description struct {
 	NvdJSONID  uint `json:"-" xml:"-"`
 
 	Lang  string
-	Value string `gorm:"size:8192"`
+	Value string `sql:"type:text"`
 }


### PR DESCRIPTION
An error occurred while fetching NVD feed with MySQL backend.

```
Error 1406: Data too long for column 'well_formed_name' at row 1
```

Change from Varcar fixed length type to text type.