### PR TITLE
Remove CHANGELOG link already removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,12 +560,6 @@ kotakanbe ([@kotakanbe](https://twitter.com/kotakanbe)) created go-cve-dictionar
 
 ----
 
-## Change Log
-
-Please see [CHANGELOG.md](https://github.com/kotakanbe/go-cve-dictionary/blob/master/CHANGELOG.md).
-
-----
-
 ## Licence
 
 Please see [LICENSE](https://github.com/kotakanbe/go-cve-dictionary/blob/master/LICENSE).


### PR DESCRIPTION
Hello.

`CHANGELOG.md` was removed in 6f5010d237248c107fe5fa3c4f849c7426c9a02f.
This PR removed link to changelog on README.
