### PR TITLE
fix(db) separate cpe data from cve in redis

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,7 +41,7 @@ install: main.go dep
 all: test
 
 lint:
-	@ go get -v github.com/golang/lint/golint
+	@ go get -v golang.org/x/lint/golint
 	$(foreach file,$(SRCS),golint $(file) || exit;)
 
 vet:

--- a/db/redis.go
+++ b/db/redis.go
@@ -19,14 +19,16 @@ import (
 # Redis Data Structure
 
 - HASH
-  ┌────────────┬──────────┬──────────┬─────────────────────────────────┐
-  │    HASH    │  FIELD   │  VALUE   │             PURPOSE             │
-  └────────────┴──────────┴──────────┴─────────────────────────────────┘
-  ┌────────────┬──────────┬───────────┬─────────────────────────────────┐
-  │CVE#${CVEID}│NVD or JVN│${CVEJSON} │Get CVEJSON by CVEID             │
-  ├────────────┼──────────┼───────────┼─────────────────────────────────┤
-  │ CVE#Meta   │${URL}    │${METAJSON}│Get FeedMeta BY URL              │
-  └────────────┴──────────┴───────────┴─────────────────────────────────┘
+  ┌──────────────┬──────────┬──────────┬──────────────────────────────────┐
+  │    HASH      │  FIELD   │  VALUE   │             PURPOSE              │
+  └──────────────┴──────────┴──────────┴──────────────────────────────────┘
+  ┌──────────────┬──────────┬───────────┬─────────────────────────────────┐
+  │CVE#${CVEID}  │NVD or JVN│${CVEJSON} │Get CVEJSON by CVEID             │
+  ├──────────────┼──────────┼───────────┼─────────────────────────────────┤
+  │CVE#C#${CVEID}│NVD or JVN│${CPEJSON} │Get CPEJSON BY CVEID             │
+  ├──────────────┼──────────┼───────────┼─────────────────────────────────┤
+  │ CVE#Meta     │${URL}    │${METAJSON}│Get FeedMeta BY URL              │
+  └──────────────┴──────────┴───────────┴─────────────────────────────────┘
 
 - ZINDE  X
   ┌─────────────────────────┬──────────┬─────────────┬─────────────────────────────────────┐
@@ -39,8 +41,9 @@ import (
 **/
 
 const (
-	dialectRedis  = "redis"
-	hashKeyPrefix = "CVE#"
+	dialectRedis     = "redis"
+	hashKeyPrefix    = "CVE#"
+	cpeHashKeyPrefix = "CVE#C#"
 )
 
 // RedisDriver is Driver for Redis
@@ -92,20 +95,24 @@ func (r *RedisDriver) CloseDB() (err error) {
 
 // Get Select Cve information from DB.
 func (r *RedisDriver) Get(cveID string) (*models.CveDetail, error) {
-	var result *redis.StringStringMapCmd
-	if result = r.conn.HGetAll(hashKeyPrefix + cveID); result.Err() != nil {
-		return nil, result.Err()
+	var cveResult, cpeResult *redis.StringStringMapCmd
+	if cveResult = r.conn.HGetAll(hashKeyPrefix + cveID); cveResult.Err() != nil {
+		return nil, cveResult.Err()
 	}
-	return r.unmarshal(cveID, result)
+	if cpeResult = r.conn.HGetAll(cpeHashKeyPrefix + cveID); cpeResult.Err() != nil {
+		return nil, cpeResult.Err()
+	}
+	return r.unmarshal(cveID, cveResult, cpeResult)
 }
 
 // GetMulti Select Cves information from DB.
 func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, error) {
 	cveDetails := map[string]models.CveDetail{}
 	pipe := r.conn.Pipeline()
-	rs := map[string]*redis.StringStringMapCmd{}
+	cveRs, cpeRs := map[string]*redis.StringStringMapCmd{}, map[string]*redis.StringStringMapCmd{}
 	for _, cveID := range cveIDs {
-		rs[cveID] = pipe.HGetAll(hashKeyPrefix + cveID)
+		cveRs[cveID] = pipe.HGetAll(hashKeyPrefix + cveID)
+		cpeRs[cveID] = pipe.HGetAll(cpeHashKeyPrefix + cveID)
 	}
 	if _, err := pipe.Exec(); err != nil {
 		if err != redis.Nil {
@@ -113,8 +120,9 @@ func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, er
 		}
 	}
 
-	for cveID, result := range rs {
-		cveDetail, err := r.unmarshal(cveID, result)
+	for cveID, cveResult := range cveRs {
+		cpeResult := cpeRs[cveID]
+		cveDetail, err := r.unmarshal(cveID, cveResult, cpeResult)
 		if err != nil {
 			return nil, err
 		}
@@ -123,11 +131,16 @@ func (r *RedisDriver) GetMulti(cveIDs []string) (map[string]models.CveDetail, er
 	return cveDetails, nil
 }
 
-func (r *RedisDriver) unmarshal(cveID string, result *redis.StringStringMapCmd) (*models.CveDetail, error) {
+func (r *RedisDriver) unmarshal(cveID string, cveResult, cpeResult *redis.StringStringMapCmd) (*models.CveDetail, error) {
 	var err error
 	jvn := &models.Jvn{}
-	if j, ok := result.Val()["Jvn"]; ok {
+	if j, ok := cveResult.Val()["Jvn"]; ok {
 		if err = json.Unmarshal([]byte(j), jvn); err != nil {
+			return nil, err
+		}
+	}
+	if jc, ok := cpeResult.Val()["Jvn"]; ok {
+		if err = json.Unmarshal([]byte(jc), &jvn.Cpes); err != nil {
 			return nil, err
 		}
 	}
@@ -136,8 +149,13 @@ func (r *RedisDriver) unmarshal(cveID string, result *redis.StringStringMapCmd) 
 	}
 
 	nvdjson := &models.NvdJSON{}
-	if j, ok := result.Val()["NvdJSON"]; ok {
+	if j, ok := cveResult.Val()["NvdJSON"]; ok {
 		if err = json.Unmarshal([]byte(j), nvdjson); err != nil {
+			return nil, err
+		}
+	}
+	if jc, ok := cpeResult.Val()["NvdJSON"]; ok {
+		if err = json.Unmarshal([]byte(jc), &nvdjson.Cpes); err != nil {
 			return nil, err
 		}
 	}
@@ -147,8 +165,13 @@ func (r *RedisDriver) unmarshal(cveID string, result *redis.StringStringMapCmd) 
 
 	nvdxml := &models.NvdXML{}
 	if nvdjson == nil {
-		if j, ok := result.Val()["Nvd"]; ok {
+		if j, ok := cveResult.Val()["Nvd"]; ok {
 			if err = json.Unmarshal([]byte(j), nvdxml); err != nil {
+				return nil, err
+			}
+		}
+		if jc, ok := cpeResult.Val()["Nvd"]; ok {
+			if err = json.Unmarshal([]byte(jc), &nvdxml.Cpes); err != nil {
 				return nil, err
 			}
 		}
@@ -225,6 +248,10 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 		for _, c := range chunked {
 			bar.Increment()
 
+			cpes := make([]models.Cpe, len(c.Jvn.Cpes))
+			copy(cpes, c.Jvn.Cpes)
+			c.Jvn.Cpes = nil
+
 			var jj []byte
 			if jj, err = json.Marshal(c.Jvn); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
@@ -234,13 +261,20 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 
-			for _, cpe := range c.Jvn.Cpes {
+			for _, cpe := range cpes {
 				if result := pipe.ZAdd(
 					fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product),
 					redis.Z{Score: 0, Member: c.CveID},
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
+			}
+			var jc []byte
+			if jc, err = json.Marshal(cpes); err != nil {
+				return fmt.Errorf("Failed to marshal json. err: %s", err)
+			}
+			if result := pipe.HSet(cpeHashKeyPrefix+c.CveID, "Jvn", string(jc)); result.Err() != nil {
+				return fmt.Errorf("Failed to HSet CPE. err: %s", result.Err())
 			}
 		}
 		if _, err = pipe.Exec(); err != nil {
@@ -281,22 +315,33 @@ func (r *RedisDriver) InsertNvdXML(cves []models.CveDetail) error {
 		for _, c := range chunked {
 			bar.Increment()
 
+			cpes := make([]models.Cpe, len(c.NvdXML.Cpes))
+			copy(cpes, c.NvdXML.Cpes)
+			c.NvdXML.Cpes = nil
+
 			var jn []byte
 			if jn, err = json.Marshal(c.NvdXML); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
 			refreshedNvds = append(refreshedNvds, c.CveID)
 			if result := pipe.HSet(hashKeyPrefix+c.CveID, "Nvd", string(jn)); result.Err() != nil {
-				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
+				return fmt.Errorf("Failed to HSet JVN CVE. err: %s", result.Err())
 			}
 
-			for _, cpe := range c.NvdXML.Cpes {
+			for _, cpe := range cpes {
 				if result := pipe.ZAdd(
 					fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product),
 					redis.Z{Score: 0, Member: c.CveID},
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
+			}
+			var jc []byte
+			if jc, err = json.Marshal(cpes); err != nil {
+				return fmt.Errorf("Failed to marshal json. err: %s", err)
+			}
+			if result := pipe.HSet(cpeHashKeyPrefix+c.CveID, "Nvd", string(jc)); result.Err() != nil {
+				return fmt.Errorf("Failed to HSet NVD CPE. err: %s", result.Err())
 			}
 		}
 		if _, err = pipe.Exec(); err != nil {
@@ -329,6 +374,9 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 		for _, c := range chunked {
 			bar.Increment()
 
+			cpes := make([]models.Cpe, len(c.NvdJSON.Cpes))
+			copy(cpes, c.NvdJSON.Cpes)
+			c.NvdJSON.Cpes = nil
 			var jn []byte
 			if jn, err = json.Marshal(c.NvdJSON); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
@@ -338,13 +386,20 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 
-			for _, cpe := range c.NvdJSON.Cpes {
+			for _, cpe := range cpes {
 				if result := pipe.ZAdd(
 					fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product),
 					redis.Z{Score: 0, Member: c.CveID},
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
+			}
+			var jc []byte
+			if jc, err = json.Marshal(cpes); err != nil {
+				return fmt.Errorf("Failed to marshal json. err: %s", err)
+			}
+			if result := pipe.HSet(cpeHashKeyPrefix+c.CveID, "NvdJSON", string(jc)); result.Err() != nil {
+				return fmt.Errorf("Failed to HSet NVD CPE. err: %s", result.Err())
 			}
 		}
 		if _, err = pipe.Exec(); err != nil {


### PR DESCRIPTION
Since the amount of data of cpe is enormous, we used useless memory space when cve information other than cpe is acquired, so we changed cpe's data separately from cve's data