### PR TITLE
fix(nvdjson): parse cpe of `disney android` in 2014 feed

### DIFF
--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -9,6 +9,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	"github.com/k0kubun/pp"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
+	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 )
 
@@ -226,7 +227,9 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 			}
 			cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
 			if err != nil {
-				return nil, err
+				// logging only
+				log.Infof("Failed to parse CpeURI %s: %s", cpe.Cpe23URI, err)
+				continue
 			}
 			cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
 			cpeBase.VersionStartIncluding = cpe.VersionStartIncluding


### PR DESCRIPTION
```
`EROR[11-07|17:14:15] Failed to convert to model. cve: CVE-2014-5606, err: Error! cannot have unquoted ? embedded in formatted string.: Parse error`
```

```
struct { Vulnerable bool "json:\"vulnerable\""; Cpe23URI string "json:\"cpe23Uri\""; VersionStartExcluding string "json:\"versionStartExcluding\""; VersionStartIncluding string "json:\"versionStartIncluding\""; VersionEndExcluding string "json:\"versionEndExcluding\""; VersionEndIncluding string "json:\"versionEndIncluding\"" }{
  Vulnerable:            true,
  Cpe23URI:              "cpe:2.3:a:disney:where\\'s_my_perry?_free:1.5.1:*:*:*:*:android:*:*",
  VersionStartExcluding: "",
  VersionStartIncluding: "",
  VersionEndExcluding:   "",
  VersionEndIncluding:   "",
}
EROR[11-07|17:16:54] Failed to convert to model. cve: CVE-2014-5606, err: Error! cannot have unquoted ? embedded in formatted string.: Parse error
```