### PR TITLE
fix(cpe): fix cpe match false positive

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -105,6 +105,13 @@ func match(specified common.WellFormedName, cpe models.Cpe) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	if wfn.Get("part") != specified.Get("part") ||
+		wfn.Get("vendor") != specified.Get("vendor") ||
+		wfn.Get("product") != specified.Get("product") {
+		return false, nil
+	}
+
 	if matching.IsEqual(specified, wfn) {
 		log.Debugf("%s equals %s", specified.String(), cpe.URI)
 		return true, nil


### PR DESCRIPTION
Also check vendor, product while matcing.

ex: 
in the current implementation, `cpe:/a:apache:struts:2.3.35` detects below CVEs.
https://nvd.nist.gov/vuln/detail/CVE-2016-3093
```
Vulnerable software and versions Switch to CPE 2.2
Configuration 1
AND
OR
 cpe:2.3:a:ognl_project:ognl:*:*:*:*:*:*:*:*    versions up to (including) 3.0.11
OR
 cpe:2.3:a:apache:struts:2.0.0:*:*:*:*:*:*:*
 cpe:2.3:a:apache:struts:2.0.1:*:*:*:*:*:*:*
 cpe:2.3:a:apache:struts:2.0.2:*:*:*:*:*:*:*
....
```
It will be detected incorrectly by matching a:ognl_project:ognl.

https://nvd.nist.gov/vuln/detail/CVE-2013-4316