### PR TITLE
fix cvss2/cvss3 lost when update CVE info.

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -551,8 +551,10 @@ func (r *RDBDriver) InsertJvn(cves []models.CveDetail) error {
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}
-				if err := tx.Unscoped().Delete(&cvss2).Error; err != nil {
-					return rollback(tx, err)
+				for _, cvss := range cvss2 {
+					if err := tx.Unscoped().Delete(cvss).Error; err != nil {
+						return rollback(tx, err)
+					}
 				}
 
 				// Delete Cvss3
@@ -561,8 +563,10 @@ func (r *RDBDriver) InsertJvn(cves []models.CveDetail) error {
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}
-				if err := tx.Unscoped().Delete(&cvss3).Error; err != nil {
-					return rollback(tx, err)
+				for _, cvss := range cvss3 {
+					if err := tx.Unscoped().Delete(cvss).Error; err != nil {
+						return rollback(tx, err)
+					}
 				}
 
 				// Delete old Cpes
@@ -730,8 +734,10 @@ func (r *RDBDriver) InsertNvdXML(cves []models.CveDetail) error {
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}
-				if err := tx.Unscoped().Delete(&cvss2).Error; err != nil {
-					return rollback(tx, err)
+				for _, cvss := range cvss2 {
+					if err := tx.Unscoped().Delete(cvss).Error; err != nil {
+						return rollback(tx, err)
+					}
 				}
 
 				// Delete old Nvd
@@ -842,8 +848,10 @@ func (r *RDBDriver) InsertNvdJSON(cves []models.CveDetail) (err error) {
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}
-				if err := tx.Unscoped().Delete(&cvss2).Error; err != nil {
-					return rollback(tx, err)
+				for _, cvss := range cvss2 {
+					if err := tx.Unscoped().Delete(cvss).Error; err != nil {
+						return rollback(tx, err)
+					}
 				}
 
 				// Delete Cvss3
@@ -852,8 +860,10 @@ func (r *RDBDriver) InsertNvdJSON(cves []models.CveDetail) (err error) {
 				if err != nil && err != gorm.ErrRecordNotFound {
 					return rollback(tx, err)
 				}
-				if err := tx.Unscoped().Delete(&cvss3).Error; err != nil {
-					return rollback(tx, err)
+				for _, cvss := range cvss3 {
+					if err := tx.Unscoped().Delete(cvss).Error; err != nil {
+						return rollback(tx, err)
+					}
 				}
 
 				// Delte old CWE


### PR DESCRIPTION
When a CVE information updated, the program deletes a old CVE infomation.
However, a parameter passed to the gorm.Delete function is a pointer of array of a cvss.
It don't have a primary key to delete.(Why? because it is a pointer of a array!)
Finaly, the gorm deletes all record in a table. ('delete from cvss2')

This will fix #114.

not fixed log
```
(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:495)
[2018-11-22 13:52:42]  [0.34ms]  SELECT * FROM "cve_details"  WHERE "cve_details"."deleted_at" IS NULL AND (("cve_details"."cve_id" = 'CVE-2017-3269')) ORDER BY "cve_details"."id" ASC LIMIT 1
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:510)
[2018-11-22 13:52:42]  [0.35ms]  SELECT * FROM "jvns"  WHERE "jvns"."deleted_at" IS NULL AND (("cve_detail_id" = '20617'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:538)
[2018-11-22 13:52:42]  [0.24ms]  SELECT * FROM "references"  WHERE "references"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[3 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 13:52:42]  [0.23ms]  DELETE FROM "references"  WHERE "references"."id" = '105234'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 13:52:42]  [0.05ms]  DELETE FROM "references"  WHERE "references"."id" = '105235'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 13:52:42]  [0.04ms]  DELETE FROM "references"  WHERE "references"."id" = '105236'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:550)
[2018-11-22 13:52:42]  [0.37ms]  SELECT * FROM "cvss2"  WHERE "cvss2"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:554)
[2018-11-22 13:52:42]  [2.26ms]  DELETE FROM "cvss2"
[11136 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:560)
[2018-11-22 13:52:42]  [0.22ms]  SELECT * FROM "cvss3"  WHERE "cvss3"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:564)
[2018-11-22 13:52:42]  [10.76ms]  DELETE FROM "cvss3"
[33753 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:570)
[2018-11-22 13:52:42]  [0.27ms]  SELECT * FROM "cpes"  WHERE "cpes"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:575)
[2018-11-22 13:52:42]  [0.17ms]  DELETE FROM "cpes"  WHERE "cpes"."id" = '174395'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:581)
[2018-11-22 13:52:42]  [0.07ms]  DELETE FROM "jvns"  WHERE "jvns"."id" = '9412'
```

fixed log
```
(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:495)
[2018-11-22 14:00:15]  [0.11ms]  SELECT * FROM "cve_details"  WHERE "cve_details"."deleted_at" IS NULL AND (("cve_details"."cve_id" = 'CVE-2017-3269')) ORDER BY "cve_details"."id" ASC LIMIT 1
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:510)
[2018-11-22 14:00:15]  [0.15ms]  SELECT * FROM "jvns"  WHERE "jvns"."deleted_at" IS NULL AND (("cve_detail_id" = '20617'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:538)
[2018-11-22 14:00:15]  [0.14ms]  SELECT * FROM "references"  WHERE "references"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[3 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 14:00:15]  [0.08ms]  DELETE FROM "references"  WHERE "references"."id" = '105234'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 14:00:15]  [0.03ms]  DELETE FROM "references"  WHERE "references"."id" = '105235'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:543)
[2018-11-22 14:00:15]  [0.03ms]  DELETE FROM "references"  WHERE "references"."id" = '105236'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:550)
[2018-11-22 14:00:15]  [0.13ms]  SELECT * FROM "cvss2"  WHERE "cvss2"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:555)
[2018-11-22 14:00:15]  [0.07ms]  DELETE FROM "cvss2"  WHERE "cvss2"."id" = '9375'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:562)
[2018-11-22 14:00:15]  [0.12ms]  SELECT * FROM "cvss3"  WHERE "cvss3"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:567)
[2018-11-22 14:00:15]  [0.12ms]  DELETE FROM "cvss3"  WHERE "cvss3"."id" = '31992'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:574)
[2018-11-22 14:00:15]  [0.16ms]  SELECT * FROM "cpes"  WHERE "cpes"."deleted_at" IS NULL AND (("jvn_id" = '9412'))
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:579)
[2018-11-22 14:00:15]  [0.13ms]  DELETE FROM "cpes"  WHERE "cpes"."id" = '174395'
[1 rows affected or returned ]

(/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/db/rdb.go:585)
[2018-11-22 14:00:15]  [0.12ms]  DELETE FROM "jvns"  WHERE "jvns"."id" = '9412'
[1 rows affected or returned ]
```