### PR TITLE
Create GetIdByCpeURI endpoint

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -20,7 +20,7 @@ type DB interface {
 	CloseDB() error
 	Get(string) (*models.CveDetail, error)
 	GetMulti([]string) (map[string]models.CveDetail, error)
-	GetIdByCpeURI(string) ([]string, error)
+	GetIDByCpeURI(string) ([]string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
 	InsertJvn([]models.CveDetail) error
 	InsertNvdXML([]models.CveDetail) error

--- a/db/db.go
+++ b/db/db.go
@@ -20,7 +20,7 @@ type DB interface {
 	CloseDB() error
 	Get(string) (*models.CveDetail, error)
 	GetMulti([]string) (map[string]models.CveDetail, error)
-	GetIDByCpeURI(string) ([]string, error)
+	GetCveIDsByCpeURI(string) ([]string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
 	InsertJvn([]models.CveDetail) error
 	InsertNvdXML([]models.CveDetail) error

--- a/db/db.go
+++ b/db/db.go
@@ -7,6 +7,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/pkg/errors"
 
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/matching"
@@ -19,6 +20,7 @@ type DB interface {
 	CloseDB() error
 	Get(string) (*models.CveDetail, error)
 	GetMulti([]string) (map[string]models.CveDetail, error)
+	GetIdByCpeURI(string) ([]string, error)
 	GetByCpeURI(string) ([]models.CveDetail, error)
 	InsertJvn([]models.CveDetail) error
 	InsertNvdXML([]models.CveDetail) error
@@ -108,7 +110,7 @@ func match(uri string, cpe models.Cpe) (bool, error) {
 
 	wfn, err := naming.UnbindURI(cpe.URI)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, "UnbindURI")
 	}
 
 	if wfn.Get("part") != specified.Get("part") ||
@@ -145,7 +147,7 @@ func match(uri string, cpe models.Cpe) (bool, error) {
 		if constraintStr != "" {
 			constraints, err := version.NewConstraint(constraintStr)
 			if err != nil {
-				return false, err
+				return false, errors.Wrap(err, "NewConstraint")
 			}
 			if constraints.Check(v) {
 				log.Debugf("%s satisfies constraints %s", v, constraintStr)

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -442,7 +442,8 @@ func (r *RDBDriver) getMatchingCpe(uri string) ([]models.Cpe, error) {
 	return filtered, nil
 }
 
-func (r *RDBDriver) GetIdByCpeURI(uri string) ([]string, error) {
+// GetIDByCpeURI Select Cve Ids by by pseudo-CPE
+func (r *RDBDriver) GetIDByCpeURI(uri string) ([]string, error) {
 	filtered, err := r.getMatchingCpe(uri)
 	if err != nil {
 		return nil, err
@@ -486,7 +487,7 @@ func (r *RDBDriver) GetIdByCpeURI(uri string) ([]string, error) {
 
 // GetByCpeURI Select Cve information from DB.
 func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
-	cveIDs, err := r.GetIdByCpeURI(uri)
+	cveIDs, err := r.GetIDByCpeURI(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -384,7 +384,7 @@ func (r *RDBDriver) CloseDB() (err error) {
 	return
 }
 
-// getMatchingCpe returns matching CPEs  by psuedo-CPE
+// getMatchingCpe returns matching CPEs  by pseudo-CPE
 func (r *RDBDriver) getMatchingCpe(uri string) ([]models.Cpe, error) {
 
 	// parse wfn, get vendor, product

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -384,8 +384,9 @@ func (r *RDBDriver) CloseDB() (err error) {
 	return
 }
 
-// GetByCpeURI Select Cve information from DB.
-func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
+// getMatchingCpe returns matching CPEs  by psuedo-CPE
+func (r *RDBDriver) getMatchingCpe(uri string) ([]models.Cpe, error) {
+
 	// parse wfn, get vendor, product
 	specified, err := naming.UnbindURI(uri)
 	if err != nil {
@@ -410,8 +411,8 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	for _, cpe := range cpes {
 		match, err := match(uri, cpe)
 		if err != nil {
-			log.Debugf("Failed to compare the version:%s %s %#v",
-				err, uri, cpe)
+			log.Debugf("Failed to compare the version:%s %s cpe_id:%d %#v",
+				err, uri, cpe.ID, cpe)
 
 			// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
 			if cpe.NvdJSONID != 0 {
@@ -438,52 +439,69 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		}
 	}
 
-	idDetail := map[uint]models.CveDetail{}
-	for _, cpe := range filtered {
-		var cveDetailID uint
-		if cpe.JvnID != 0 {
-			jvn := models.Jvn{}
-			err = r.conn.Select("cve_detail_id").Where("ID = ?", cpe.JvnID).First(&jvn).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return nil, err
-			}
-			cveDetailID = jvn.CveDetailID
-		} else if cpe.NvdXMLID != 0 {
-			nvd := models.NvdXML{}
-			err = r.conn.Select("cve_detail_id").Where("ID = ?", cpe.NvdXMLID).First(&nvd).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return nil, err
-			}
-			cveDetailID = nvd.CveDetailID
-		} else if cpe.NvdJSONID != 0 {
-			json := models.NvdJSON{}
-			err = r.conn.Select("cve_detail_id").Where("ID = ?", cpe.NvdJSONID).First(&json).Error
-			if err != nil && err != gorm.ErrRecordNotFound {
-				return nil, err
-			}
-			cveDetailID = json.CveDetailID
-		}
+	return filtered, nil
+}
 
-		if _, ok := idDetail[cveDetailID]; ok {
-			continue
-		}
-
-		cveDetail := models.CveDetail{}
-		err = r.conn.Select("cve_id").Where("ID = ?", cveDetailID).First(&cveDetail).Error
-		if err != nil && err != gorm.ErrRecordNotFound {
-			return nil, err
-		}
-		cveID := cveDetail.CveID
-		detail, err := r.Get(cveID)
-		if err != nil {
-			return nil, err
-		}
-		idDetail[cveDetailID] = *detail
+func (r *RDBDriver) GetIdByCpeURI(uri string) ([]string, error) {
+	filtered, err := r.getMatchingCpe(uri)
+	if err != nil {
+		return nil, err
 	}
 
-	details := []models.CveDetail{}
-	for _, d := range idDetail {
-		details = append(details, d)
+	cveIDs := make([]string, len(filtered))
+
+	// The cpes table is de-normalized. So the `First` is correct, don't be mislead.
+	for i, cpe := range filtered {
+		if cpe.JvnID != 0 {
+			jvn := models.Jvn{}
+			err = r.conn.Select("cve_id").Where("ID = ?", cpe.JvnID).First(&jvn).Error
+			if err != nil && err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+			cveIDs[i] = jvn.CveID
+		} else if cpe.NvdXMLID != 0 {
+			nvd := models.NvdXML{}
+			err = r.conn.Select("cve_id").Where("ID = ?", cpe.NvdXMLID).First(&nvd).Error
+			if err != nil && err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+			cveIDs[i] = nvd.CveID
+		} else if cpe.NvdJSONID != 0 {
+			json := models.NvdJSON{}
+			err = r.conn.Select("cve_id").Where("ID = ?", cpe.NvdJSONID).First(&json).Error
+			if err != nil && err != gorm.ErrRecordNotFound {
+				return nil, err
+			}
+			cveIDs[i] = json.CveID
+		}
+
+		// If we didn't find a CVE something is weird.
+		if cveIDs[i] == "" {
+			log.Infof("Missing cve_id for %s (id: %d)", cpe.URI, cpe.ID)
+		}
+	}
+
+	return cveIDs, nil
+}
+
+// GetByCpeURI Select Cve information from DB.
+func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
+	cveIDs, err := r.GetIdByCpeURI(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	cveDetails, err := r.GetMulti(cveIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert from map to array
+	details := make([]models.CveDetail, len(cveDetails))
+	i := 0
+	for _, d := range cveDetails {
+		details[i] = d
+		i++
 		log.Debugf("%s", d.CveID)
 	}
 	return details, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -384,8 +384,8 @@ func (r *RDBDriver) CloseDB() (err error) {
 	return
 }
 
-// getMatchingCpe returns matching CPEs  by pseudo-CPE
-func (r *RDBDriver) getMatchingCpe(uri string) ([]models.Cpe, error) {
+// getMatchingCpes returns matching CPEs  by pseudo-CPE
+func (r *RDBDriver) getMatchingCpes(uri string) ([]models.Cpe, error) {
 
 	// parse wfn, get vendor, product
 	specified, err := naming.UnbindURI(uri)
@@ -442,9 +442,9 @@ func (r *RDBDriver) getMatchingCpe(uri string) ([]models.Cpe, error) {
 	return filtered, nil
 }
 
-// GetIDByCpeURI Select Cve Ids by by pseudo-CPE
-func (r *RDBDriver) GetIDByCpeURI(uri string) ([]string, error) {
-	filtered, err := r.getMatchingCpe(uri)
+// GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
+func (r *RDBDriver) GetCveIDsByCpeURI(uri string) ([]string, error) {
+	filtered, err := r.getMatchingCpes(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func (r *RDBDriver) GetIDByCpeURI(uri string) ([]string, error) {
 
 // GetByCpeURI Select Cve information from DB.
 func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
-	cveIDs, err := r.GetIDByCpeURI(uri)
+	cveIDs, err := r.GetCveIDsByCpeURI(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -190,7 +190,7 @@ func (r *RedisDriver) unmarshal(cveID string, cveResult, cpeResult *redis.String
 	}, nil
 }
 
-// GetIdByCpeURI returns cve IDs by psuedo-CPE
+// GetIdByCpeURI returns cve IDs by pseudo-CPE
 func (r *RedisDriver) GetIdByCpeURI(uri string) ([]string, error) {
 	// TODO
 	return nil, nil

--- a/db/redis.go
+++ b/db/redis.go
@@ -190,8 +190,8 @@ func (r *RedisDriver) unmarshal(cveID string, cveResult, cpeResult *redis.String
 	}, nil
 }
 
-// GetIdByCpeURI returns cve IDs by pseudo-CPE
-func (r *RedisDriver) GetIdByCpeURI(uri string) ([]string, error) {
+// GetIDByCpeURI Select Cve Ids by by pseudo-CPE
+func (r *RedisDriver) GetIDByCpeURI(uri string) ([]string, error) {
 	// TODO
 	return nil, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -190,8 +190,8 @@ func (r *RedisDriver) unmarshal(cveID string, cveResult, cpeResult *redis.String
 	}, nil
 }
 
-// GetIDByCpeURI Select Cve Ids by by pseudo-CPE
-func (r *RedisDriver) GetIDByCpeURI(uri string) ([]string, error) {
+// GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
+func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, error) {
 	// TODO
 	return nil, nil
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -190,6 +190,12 @@ func (r *RedisDriver) unmarshal(cveID string, cveResult, cpeResult *redis.String
 	}, nil
 }
 
+// GetIdByCpeURI returns cve IDs by psuedo-CPE
+func (r *RedisDriver) GetIdByCpeURI(uri string) ([]string, error) {
+	// TODO
+	return nil, nil
+}
+
 // GetByCpeURI Select Cve information from DB.
 func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	specified, err := naming.UnbindURI(uri)


### PR DESCRIPTION
This creates an GetIdByCpeURI endpoint on the DB interface.

The rdb implementation splits the existing `GetByCpeURI` call into an `GetIdByCpeURI ` and the existing `GetMulti`. This reduces the duplication, while exposing intermediary data.

(I’m not sure if this is desired, but I found it useful for the tools I’m writing)

Fixes https://github.com/kotakanbe/go-cve-dictionary/issues/124