### PR TITLE
Collect US-CERT/JPCERT alerts from NVD/JVN feeds

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -131,6 +131,8 @@ func (r *RDBDriver) MigrateDB() error {
 	// certs
 	errs = append(errs, r.conn.Model(&models.Cert{}).
 		AddIndex("idx_certs_jvn_id", "jvn_id").Error)
+	errs = append(errs, r.conn.Model(&models.Cert{}).
+		AddIndex("idx_certs_nvd_json_id", "nvd_json_id").Error)
 
 	// cpes
 	errs = append(errs, r.conn.Model(&models.Cpe{}).
@@ -311,6 +313,13 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 			return nil, err
 		}
 		c.NvdJSON.References = refs
+
+		certs := []models.Cert{}
+		err = r.conn.Model(&json).Related(&certs, "Certs").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		c.NvdJSON.Certs = certs
 
 		cpes := []models.Cpe{}
 		err = r.conn.Model(&json).Related(&cpes, "Cpes").Error
@@ -983,6 +992,18 @@ func (r *RDBDriver) InsertNvdJSON(cves []models.CveDetail) (err error) {
 				}
 				for _, r := range refs {
 					if err := tx.Unscoped().Delete(r).Error; err != nil {
+						return rollback(tx, err)
+					}
+				}
+
+				// Delete Certs
+				certs := []models.Cert{}
+				err = tx.Model(&json).Related(&certs, "Certs").Error
+				if err != nil && err != gorm.ErrRecordNotFound {
+					return rollback(tx, err)
+				}
+				for _, l := range certs {
+					if err := tx.Unscoped().Delete(l).Error; err != nil {
 						return rollback(tx, err)
 					}
 				}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -87,6 +87,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.NvdJSON{},
 		&models.Jvn{},
 		&models.Reference{},
+		&models.Cert{},
 		&models.Cpe{},
 		&models.EnvCpe{},
 		&models.Cwe{},
@@ -126,6 +127,10 @@ func (r *RDBDriver) MigrateDB() error {
 		AddIndex("idx_references_jvn_id", "jvn_id").Error)
 	errs = append(errs, r.conn.Model(&models.Reference{}).
 		AddIndex("idx_references_nvd_json_id", "nvd_json_id").Error)
+
+	// certs
+	errs = append(errs, r.conn.Model(&models.Cert{}).
+		AddIndex("idx_certs_jvn_id", "jvn_id").Error)
 
 	// cpes
 	errs = append(errs, r.conn.Model(&models.Cpe{}).
@@ -225,6 +230,13 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 			return nil, err
 		}
 		c.Jvn.References = jvnRefs
+
+		certs := []models.Cert{}
+		err = r.conn.Model(&jvn).Related(&certs, "Certs").Error
+		if err != nil && err != gorm.ErrRecordNotFound {
+			return nil, err
+		}
+		c.Jvn.Certs = certs
 
 		cvss2 := models.Cvss2{}
 		err = r.conn.Model(&jvn).Related(&cvss2, "Cvss2").Error
@@ -579,6 +591,18 @@ func (r *RDBDriver) InsertJvn(cves []models.CveDetail) error {
 				}
 				for _, r := range refs {
 					if err := tx.Unscoped().Delete(r).Error; err != nil {
+						return rollback(tx, err)
+					}
+				}
+
+				// Delete Certs
+				certs := []models.Cert{}
+				err = tx.Model(&jvn).Related(&certs, "Certs").Error
+				if err != nil && err != gorm.ErrRecordNotFound {
+					return rollback(tx, err)
+				}
+				for _, l := range certs {
+					if err := tx.Unscoped().Delete(l).Error; err != nil {
 						return rollback(tx, err)
 					}
 				}

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -7,13 +7,15 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/PuerkitoBio/goquery"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/db"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
-	log "github.com/kotakanbe/go-cve-dictionary/log"
+	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/kotakanbe/go-cve-dictionary/util"
+	"net/http"
+	"github.com/PuerkitoBio/goquery"
+	"net/url"
 )
 
 // Meta ... https://jvndb.jvn.jp/ja/feed/checksum.txt
@@ -63,6 +65,11 @@ type Cvss struct {
 	Severity string `xml:"severity,attr"`
 	Vector   string `xml:"vector,attr"`
 	Version  string `xml:"version,attr"`
+}
+
+// CertLink is a structure to temporarily store reference URLs.
+type CertLink struct {
+	Link string
 }
 
 // ListFetchedFeeds list fetched feeds information
@@ -267,21 +274,20 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 	}
 
 	// Certs
-	certs := []models.Cert{}
-	for _, l := range item.References {
-		if l.Source == "JPCERT-AT" {
-			doc, err := goquery.NewDocument(l.URL)
-			if err != nil {
-				return nil, err
+	links := []CertLink{}
+	for _, ref := range item.References {
+		if ref.Source == "JPCERT-AT" {
+			link := CertLink{
+				Link: ref.URL,
 			}
-			title := doc.Find("title").Text()
-
-			cert := models.Cert{
-				Title: title,
-				Link:  l.URL,
-			}
-			certs = append(certs, cert)
+			links = append(links, link)
 		}
+	}
+
+	certs, err := collectCertLinks(links)
+	if err != nil {
+		return nil,
+			fmt.Errorf("Failed to collect links. err: %s", err)
 	}
 
 	// Cpes
@@ -362,6 +368,79 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 		cves = append(cves, cve)
 	}
 	return
+}
+
+func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
+	var proxyURL *url.URL
+	httpCilent := &http.Client{}
+	if c.Conf.HTTPProxy != "" {
+		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
+			return nil, fmt.Errorf("failed to parse proxy url: %s", err)
+		}
+		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	}
+
+	reqChan := make(chan string, 10)
+	resChan := make(chan models.Cert, 10)
+	errChan := make(chan error, len(links))
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	go func() {
+		for _, ref := range links {
+			reqChan <- ref.Link
+		}
+	}()
+
+	concurrency := 3
+	tasks := util.GenWorkers(concurrency)
+	certs = []models.Cert{}
+
+	for _, l := range links {
+		tasks <- func() {
+			req := <-reqChan
+			reqURL, err := http.NewRequest("GET", req, nil)
+			if err != nil {
+				errChan <- err
+			}
+
+			res, err := httpCilent.Do(reqURL)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			defer res.Body.Close()
+
+			doc, err := goquery.NewDocumentFromReader(res.Body)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			title := doc.Find("title").Text()
+			resChan <- models.Cert{
+				Title: title,
+				Link:  l.Link,
+			}
+		}
+	}
+
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range links {
+		select {
+		case res := <-resChan:
+			certs = append(certs, res)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
+		}
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
+	}
+	return certs, nil
 }
 
 var cvss2VectorMap = map[string]string{

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/PuerkitoBio/goquery"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
 	"github.com/kotakanbe/go-cve-dictionary/db"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
@@ -265,6 +266,24 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 		refs = append(refs, ref)
 	}
 
+	// Certs
+	certs := []models.Cert{}
+	for _, l := range item.References {
+		if l.Source == "JPCERT-AT" {
+			doc, err := goquery.NewDocument(l.URL)
+			if err != nil {
+				return nil, err
+			}
+			title := doc.Find("title").Text()
+
+			cert := models.Cert{
+				Title: title,
+				Link:  l.URL,
+			}
+			certs = append(certs, cert)
+		}
+	}
+
 	// Cpes
 	cpes := []models.Cpe{}
 	for _, c := range item.Cpes {
@@ -334,6 +353,7 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 
 				References: refs,
 				Cpes:       cpes,
+				Certs:      certs,
 
 				PublishedDate:    publish,
 				LastModifiedDate: modified,

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -6,11 +6,16 @@ import (
 	"strings"
 	"time"
 
-	version "github.com/hashicorp/go-version"
+	c "github.com/kotakanbe/go-cve-dictionary/config"
+	"github.com/hashicorp/go-version"
 	"github.com/k0kubun/pp"
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
 	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/kotakanbe/go-cve-dictionary/util"
+	"net/url"
+	"net/http"
+	"github.com/PuerkitoBio/goquery"
 )
 
 // FetchConvert Fetch CVE vulnerability information from NVD
@@ -96,7 +101,8 @@ type CveItem struct {
 		} `json:"problemtype"`
 		References struct {
 			ReferenceData []struct {
-				URL string `json:"url"`
+				URL  string   `json:"url"`
+				TAGS []string `json:"tags"`
 			} `json:"reference_data"`
 		} `json:"references"`
 		Description struct {
@@ -176,6 +182,11 @@ type CveItem struct {
 	LastModifiedDate string `json:"lastModifiedDate"`
 }
 
+// CertLink is a structure to temporarily store reference URLs.
+type CertLink struct {
+	Link string
+}
+
 // convertToModel converts Nvd JSON to model structure.
 func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	//References
@@ -185,6 +196,24 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 			Link: r.URL,
 		}
 		refs = append(refs, ref)
+	}
+
+	// Certs
+	links := []CertLink{}
+	for _, ref := range item.Cve.References.ReferenceData {
+		tag := strings.Join(ref.TAGS, " ")
+		if strings.Contains(ref.URL, "ncas/alerts") || strings.Contains(ref.URL, "cas/techalerts") || strings.Contains(tag, "US Government Resource") {
+			link := CertLink{
+				Link: ref.URL,
+			}
+			links = append(links, link)
+		}
+	}
+
+	certs, err := collectCertLinks(links)
+	if err != nil {
+		return nil,
+			fmt.Errorf("Failed to collect links. err: %s", err)
 	}
 
 	// Cwes
@@ -360,10 +389,90 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 			Cpes:             cpes,
 			References:       refs,
 			Affects:          affects,
+			Certs:            certs,
 			PublishedDate:    publish,
 			LastModifiedDate: modified,
 		},
 	}, nil
+}
+
+func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
+	var proxyURL *url.URL
+	httpCilent := &http.Client{}
+	if c.Conf.HTTPProxy != "" {
+		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
+			return nil, fmt.Errorf("failed to parse proxy url: %s", err)
+		}
+		httpCilent = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	}
+
+	reqChan := make(chan string, 10)
+	resChan := make(chan models.Cert, 10)
+	errChan := make(chan error, len(links))
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	go func() {
+		for _, ref := range links {
+			reqChan <- ref.Link
+		}
+	}()
+
+	concurrency := 3
+	tasks := util.GenWorkers(concurrency)
+	certs = []models.Cert{}
+
+	for _, l := range links {
+		tasks <- func() {
+			req := <-reqChan
+			reqURL, err := http.NewRequest("GET", req, nil)
+			if err != nil {
+				errChan <- err
+			}
+
+			res, err := httpCilent.Do(reqURL)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			defer res.Body.Close()
+
+			doc, err := goquery.NewDocumentFromReader(res.Body)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			var title string
+			if strings.Contains(l.Link, "kb.cert.org") || strings.Contains(l.Link, "kaspersky.com") {
+				title = doc.Find("title").Text()
+			} else {
+				title = doc.Find("#page-sub-title").Text()
+			}
+			res.Body.Close()
+			resChan <- models.Cert{
+				Title: title,
+				Link:  l.Link,
+			}
+		}
+	}
+
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range links {
+		select {
+		case res := <-resChan:
+			certs = append(certs, res)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
+		}
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
+	}
+	return certs, nil
 }
 
 func checkIfVersionParsable(cpeBase *models.CpeBase) bool {

--- a/models/models.go
+++ b/models/models.go
@@ -212,6 +212,7 @@ type Jvn struct {
 	Cpes       []Cpe `json:",omitempty"`
 	References []Reference
 
+	Certs            []Cert
 	PublishedDate    time.Time
 	LastModifiedDate time.Time
 }
@@ -288,6 +289,16 @@ type Reference struct {
 
 	Source string
 	Link   string `sql:"type:text"`
+}
+
+// Cert is Child model of Jvn/Nvd.
+// It holds CERT alerts.
+type Cert struct {
+	gorm.Model `json:"-" xml:"-"`
+	JvnID      uint `json:"-" xml:"-"`
+
+	Title string
+	Link  string `sql:"type:text"`
 }
 
 // Affect has vendor/product/version info in NVD JSON

--- a/models/models.go
+++ b/models/models.go
@@ -192,6 +192,7 @@ type NvdJSON struct {
 	References []Reference
 
 	// Assigner         string
+	Certs            []Cert
 	PublishedDate    time.Time
 	LastModifiedDate time.Time
 }
@@ -296,8 +297,9 @@ type Reference struct {
 type Cert struct {
 	gorm.Model `json:"-" xml:"-"`
 	JvnID      uint `json:"-" xml:"-"`
+	NvdJSONID  uint `json:"-" xml:"-"`
 
-	Title string
+	Title string `sql:"type:text"`
 	Link  string `sql:"type:text"`
 }
 


### PR DESCRIPTION
add a DB table to collect undetected alerts

- [x] DB model definition

- [x] Customize convertToModel in fetcher

- [x] CERT scraping

  - [x] Getting Title Information

  - [x] Parallelization using Goroutine

- [x] Insert DB

- [x] NVDJSON support

- [x] Proxy support

You can check DB schema using `sqlite3`.

```
sqlite> .table
affects       cve_details   cvss3         env_cpes      nvd_jsons
certs         cvss2         cwes          feed_meta     nvd_xmls
cpes          cvss2_extras  descriptions  jvns          references
sqlite> .schema certs
CREATE TABLE IF NOT EXISTS "certs" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"deleted_at" datetime,"jvn_id" integer,"title" varchar(255),"link" text );
CREATE INDEX idx_certs_deleted_at ON "certs"(deleted_at) ;
CREATE INDEX idx_certs_jvn_id ON "certs"(jvn_id) ;
sqlite> .headers ON
sqlite> .mode column
sqlite> SELECT * FROM certs;
```