### PR TITLE
Add server route for GetCveIDsByCpeURI

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,7 @@ func Start(logDir string, driver db.DB) error {
 	e.GET("/health", health())
 	e.GET("/cves/:id", getCve(driver))
 	e.POST("/cpes", getCveByCpeName(driver))
+	e.POST("/cpes/ids", getCveIDsByCpeName(driver))
 
 	bindURL := fmt.Sprintf("%s:%s", config.Conf.Bind, config.Conf.Port)
 	log.Infof("Listening on %s", bindURL)
@@ -88,5 +89,22 @@ func getCveByCpeName(driver db.DB) echo.HandlerFunc {
 			return err
 		}
 		return c.JSON(http.StatusOK, &cveDetails)
+	}
+}
+
+func getCveIDsByCpeName(driver db.DB) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		cpe := cpeName{}
+		err := c.Bind(&cpe)
+		if err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+		cveIDs, err := driver.GetCveIDsByCpeURI(cpe.Name)
+		if err != nil {
+			log.Errorf("%s", err)
+			return err
+		}
+		return c.JSON(http.StatusOK, &cveIDs)
 	}
 }


### PR DESCRIPTION
This just adds an endpoint for the new functionality in https://github.com/kotakanbe/go-cve-dictionary/pull/126