### PR TITLE
fix(meta): not update LastModifiedDate

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -1069,7 +1069,7 @@ func (r *RDBDriver) UpsertFeedHash(mm models.FeedMeta) error {
 		}
 	} else {
 		meta.Hash = mm.Hash
-		m.LastModifiedDate = mm.LastModifiedDate
+		meta.LastModifiedDate = mm.LastModifiedDate
 		if err := tx.Save(&meta).Error; err != nil {
 			return rollback(tx, err)
 		}


### PR DESCRIPTION
Fix a bug that not update LastModifiedData of feed_meta table in rdb.