### PR TITLE
update alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 
 
-FROM alpine:3.7
+FROM alpine:3.11
 
 MAINTAINER hikachan sadayuki-matsuno
 


### PR DESCRIPTION
I update the alpine version to 3.11 in the image becaue support for alpine 3.7 has ended.
I built docker image, tested fetching in the container and got the following result
```
/go/src/github.com/kotakanbe/go-cve-dictionary # go-cve-dictionary fetchnvd -latest
INFO[03-13|06:41:40] Fetching... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.meta 
INFO[03-13|06:41:40] Fetching... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-recent.meta 
INFO[03-13|06:41:42] Fetched... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.meta 
INFO[03-13|06:41:42] Fetched... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-recent.meta 
INFO[03-13|06:41:42]      Newly: https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.json.gz 
INFO[03-13|06:41:42]      Newly: https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-recent.json.gz 
INFO[03-13|06:41:42] Fetching... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.json.gz 
INFO[03-13|06:41:42] Fetching... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-recent.json.gz 
INFO[03-13|06:41:43] Fetched... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-recent.json.gz 
INFO[03-13|06:41:44] Fetched... https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-modified.json.gz 
INFO[03-13|06:41:48] Fetched 1635 CVEs 
INFO[03-13|06:41:48] Inserting NVD into DB (sqlite3). 
INFO[03-13|06:41:48] Inserting fetched CVEs... 
1635 / 1635 [----------------------------------------------------------------------------------------------------] 100.00% 64 p/s
INFO[03-13|06:42:14] Refreshed 943 NvdJSONs. 
```