### PR TITLE
fix(logger): panic if no file permission #153

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -30,16 +30,22 @@ func SetLogger(logDir string, quiet, debug, logJSON bool) {
 
 	if _, err := os.Stat(logDir); os.IsNotExist(err) {
 		if err := os.Mkdir(logDir, 0700); err != nil {
-			logger.Error("Failed to create log directory", "err", err)
+			logger.Error("Failed to create a log directory", "err", err)
 		}
 	}
 	var hundler logger.Handler
 	if _, err := os.Stat(logDir); err == nil {
 		logPath := filepath.Join(logDir, "cve-dictionary.log")
-		hundler = logger.MultiHandler(
-			logger.Must.FileHandler(logPath, logFormat),
-			lvlHundler,
-		)
+		if err := ioutil.WriteFile(logPath, []byte{}, 0700); err != nil {
+			logger.Error("Failed to create a log file", "err", err)
+			hundler = lvlHundler
+		} else {
+			hundler = logger.MultiHandler(
+				logger.Must.FileHandler(logPath, logFormat),
+				lvlHundler,
+			)
+		}
+
 	} else {
 		hundler = lvlHundler
 	}


### PR DESCRIPTION
Fixes #153 

```panic: open /var/log/vuls/cve-dictionary.log: permission denied

goroutine 1 [running]:
github.com/inconshreveable/log15.must(...)
        /home/ubuntu/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:340
github.com/inconshreveable/log15.muster.FileHandler(0xc000240b00, 0x20, 0x19d76c0, 0x169aef0, 0x20, 0x0)
        /home/ubuntu/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20180818164646-67afb5ed74ec/handler.go:348 +0x8a
github.com/kotakanbe/go-cve-dictionary/log.SetLogger(0x15fa9c6, 0xd, 0x100)
        /home/ubuntu/go/pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.4.1/log/log.go:40 +0x227
github.com/future-architect/vuls/commands.(*ReportCmd).Execute(0xc0000ee2a0, 0x19fd5a0, 0xc0000c2010, 0xc0000c8840, 0x0, 0x0, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/future-architect/vuls/commands/report.go:195 +0xc3
github.com/google/subcommands.(*Commander).Execute(0xc0000ca000, 0x19fd5a0, 0xc0000c2010, 0x0, 0x0, 0x0, 0xc000428f38)
        /home/ubuntu/go/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:142 +0x2f9
github.com/google/subcommands.Execute(...)
        /home/ubuntu/go/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:420
main.main()
        /home/ubuntu/go/src/github.com/future-architect/vuls/main.go:37 +0x387```