### PR TITLE
fix(list): list subcommand displays "Unknown" 

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -64,7 +64,7 @@ func (f FeedMeta) color(str string) string {
 }
 
 func (f FeedMeta) source() string {
-	if strings.Contains(f.URL, "nvdcve-1.0-") {
+	if strings.Contains(f.URL, "nvdcve-1.1-") {
 		return nvdjson
 	} else if strings.Contains(f.URL, "jvndb") {
 		return jvn
@@ -89,7 +89,7 @@ func (f FeedMeta) Year() (year string, xml bool, err error) {
 	switch f.source() {
 	case nvdjson:
 		return strings.TrimSuffix(
-			strings.Split(f.URL, "nvdcve-1.0-")[1], ".json.gz"), false, nil
+			strings.Split(f.URL, "nvdcve-1.1-")[1], ".json.gz"), false, nil
 	case jvn:
 		if strings.HasSuffix(f.URL, "jvndb.rdf") {
 			return "modified", true, nil


### PR DESCRIPTION
I fixed the bug that list subcommand displays incorrect result "Unknown".

```
+---------+------+------------+---------+---------+
| SOURCE  | YEAR |   STATUS   | FETCHED | LATEST  |
+---------+------+------------+---------+---------+
| Unknown |      | Up-to-Date | Unknown | Unknown |
| Unknown |      | Up-to-Date | Unknown | Unknown |
| Unknown |      | Up-to-Date | Unknown | Unknown |
| Unknown |      | Up-to-Date | Unknown | Unknown |
+---------+------+------------+---------+---------+
```