### PR TITLE
fix flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main() {
 	subcommands.Register(&commands.FetchNvdCmd{}, "fetchnvd")
 	subcommands.Register(&commands.ListCmd{}, "list")
 
+	var v = flag.Bool("v", false, "Show version")
+
 	if envArgs := os.Getenv("GO_CVE_DICTIONARY_ARGS"); 0 < len(envArgs) {
 		if err := flag.CommandLine.Parse(strings.Fields(envArgs)); err != nil {
 			fmt.Printf("Failed to parse ENV_VARs: %s", err)
@@ -38,7 +40,6 @@ func main() {
 		flag.Parse()
 	}
 
-	var v = flag.Bool("v", false, "Show version")
 	if *v {
 		fmt.Printf("go-cve-dictionary %s %s\n", version, revision)
 		os.Exit(int(subcommands.ExitSuccess))


### PR DESCRIPTION
`flag.Parse()` was being called before -v flag was defined.