### PR TITLE
feat(fetchnvd): add light flg to ignore cpe releated data

### DIFF
--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -30,7 +30,7 @@ type FetchNvdCmd struct {
 	last2Y    bool
 	years     bool
 	httpProxy string
-	ignoreCPE bool
+	light     bool
 }
 
 // Name return subcommand name
@@ -54,7 +54,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-quiet]
 		[-log-dir=/path/to/log]
 		[-log-json]
-		[-ignore-cpe]
+		[-light]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in ` + "`seq 2002 $(date +\"%Y\")`;" + ` do go-cve-dictionary fetchnvd -years $i; done
@@ -95,7 +95,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"http://proxy-url:port (default: empty)",
 	)
 
-	f.BoolVar(&p.ignoreCPE, "ignore-cpe", false, "Ignore CPE data(Too heavy). If you don't do cpe-based scan, specify this flag")
+	f.BoolVar(&p.light, "light", false, "Don't collect *HEAVY* CPE relate data")
 }
 
 // Execute execute
@@ -108,7 +108,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	c.Conf.DBPath = p.dbpath
 	c.Conf.DBType = p.dbtype
 	c.Conf.HTTPProxy = p.httpProxy
-	c.Conf.IgnoreCPE = p.ignoreCPE
+	c.Conf.Light = p.light
 
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -19,20 +19,18 @@ import (
 
 // FetchNvdCmd is Subcommand for fetch Nvd information.
 type FetchNvdCmd struct {
-	debug    bool
-	debugSQL bool
-	quiet    bool
-	logDir   string
-	logJSON  bool
-
-	dbpath string
-	dbtype string
-
-	Latest bool
-	last2Y bool
-	years  bool
-
+	debug     bool
+	debugSQL  bool
+	quiet     bool
+	logDir    string
+	logJSON   bool
+	dbpath    string
+	dbtype    string
+	Latest    bool
+	last2Y    bool
+	years     bool
 	httpProxy string
+	ignoreCPE bool
 }
 
 // Name return subcommand name
@@ -56,6 +54,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-quiet]
 		[-log-dir=/path/to/log]
 		[-log-json]
+		[-ignore-cpe]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in ` + "`seq 2002 $(date +\"%Y\")`;" + ` do go-cve-dictionary fetchnvd -years $i; done
@@ -95,6 +94,8 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"",
 		"http://proxy-url:port (default: empty)",
 	)
+
+	f.BoolVar(&p.ignoreCPE, "ignore-cpe", false, "Ignore CPE data(Too heavy). If you don't do cpe-based scan, specify this flag")
 }
 
 // Execute execute
@@ -107,6 +108,7 @@ func (p *FetchNvdCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	c.Conf.DBPath = p.dbpath
 	c.Conf.DBType = p.dbtype
 	c.Conf.HTTPProxy = p.httpProxy
+	c.Conf.IgnoreCPE = p.ignoreCPE
 
 	if !c.Conf.Validate() {
 		return subcommands.ExitUsageError

--- a/config/config.go
+++ b/config/config.go
@@ -13,9 +13,10 @@ var Conf Config
 
 // Config has config
 type Config struct {
-	Debug    bool
-	DebugSQL bool
-	Quiet    bool
+	Debug     bool
+	DebugSQL  bool
+	Quiet     bool
+	IgnoreCPE bool
 
 	DumpPath string
 	DBPath   string

--- a/config/config.go
+++ b/config/config.go
@@ -13,10 +13,10 @@ var Conf Config
 
 // Config has config
 type Config struct {
-	Debug     bool
-	DebugSQL  bool
-	Quiet     bool
-	IgnoreCPE bool
+	Debug    bool
+	DebugSQL bool
+	Quiet    bool
+	Light    bool
 
 	DumpPath string
 	DBPath   string

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -277,106 +277,107 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 		}
 	}
 
-	// Affects
 	affects := []models.Affect{}
-	for _, vendor := range item.Cve.Affects.Vendor.VendorData {
-		for _, prod := range vendor.Product.ProductData {
-			for _, version := range prod.Version.VersionData {
-				affects = append(affects, models.Affect{
-					Vendor:  vendor.VendorName,
-					Product: prod.ProductName,
-					Version: version.VersionValue,
-				})
+	cpes := []models.Cpe{}
+	if !c.Conf.IgnoreCPE {
+		// Affects
+		for _, vendor := range item.Cve.Affects.Vendor.VendorData {
+			for _, prod := range vendor.Product.ProductData {
+				for _, version := range prod.Version.VersionData {
+					affects = append(affects, models.Affect{
+						Vendor:  vendor.VendorName,
+						Product: prod.ProductName,
+						Version: version.VersionValue,
+					})
+				}
 			}
 		}
-	}
 
-	// Traverse Cpe, EnvCpe
-	cpes := []models.Cpe{}
-	for _, node := range item.Configurations.Nodes {
-		if node.Negate {
-			continue
-		}
-
-		nodeCpes := []models.Cpe{}
-		for _, cpe := range node.Cpes {
-			// if !cpe.Vulnerable {
-			// CVE-2017-14492 and CVE-2017-8581 has a cpe that has vulenrable:false.
-			// But these vulnerable: false cpe is also vulnerable...
-			// So, ignore the vulerable flag of this layer(under nodes>cpe)
-			// }
-			cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-			if err != nil {
-				// logging only
-				log.Infof("Failed to parse CpeURI %s: %s", cpe.Cpe23URI, err)
+		for _, node := range item.Configurations.Nodes {
+			if node.Negate {
 				continue
 			}
-			cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-			cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-			cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-			cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-			nodeCpes = append(nodeCpes, models.Cpe{
-				CpeBase: *cpeBase,
-			})
-			if !checkIfVersionParsable(cpeBase) {
-				return nil, fmt.Errorf(
-					"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
-					item.Cve.CveDataMeta.ID,
-					pp.Sprintf("%v", *item),
-				)
-			}
-		}
-		for _, child := range node.Children {
-			for _, cpe := range child.Cpes {
-				if cpe.Vulnerable {
-					cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-					if err != nil {
-						return nil, err
-					}
-					cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-					cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-					cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-					cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-					nodeCpes = append(nodeCpes, models.Cpe{
-						CpeBase: *cpeBase,
-					})
-					if !checkIfVersionParsable(cpeBase) {
-						return nil, fmt.Errorf(
-							"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
-							item.Cve.CveDataMeta.ID,
-							pp.Sprintf("%v", *item),
-						)
-					}
-				} else {
-					if node.Operator == "AND" {
-						for i, c := range nodeCpes {
-							cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-							if err != nil {
-								return nil, err
-							}
-							cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-							cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-							cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-							cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-							nodeCpes[i].EnvCpes = append(c.EnvCpes, models.EnvCpe{
-								CpeBase: *cpeBase,
-							})
 
-							if !checkIfVersionParsable(cpeBase) {
-								return nil, fmt.Errorf(
-									"Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: Version parse err: %s, Content:%s",
-									item.Cve.CveDataMeta.ID,
-									pp.Sprintf("%v", *item),
-								)
+			nodeCpes := []models.Cpe{}
+			for _, cpe := range node.Cpes {
+				// if !cpe.Vulnerable {
+				// CVE-2017-14492 and CVE-2017-8581 has a cpe that has vulenrable:false.
+				// But these vulnerable: false cpe is also vulnerable...
+				// So, ignore the vulerable flag of this layer(under nodes>cpe)
+				// }
+				cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+				if err != nil {
+					// logging only
+					log.Infof("Failed to parse CpeURI %s: %s", cpe.Cpe23URI, err)
+					continue
+				}
+				cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+				cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+				cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+				cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+				nodeCpes = append(nodeCpes, models.Cpe{
+					CpeBase: *cpeBase,
+				})
+				if !checkIfVersionParsable(cpeBase) {
+					return nil, fmt.Errorf(
+						"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
+						item.Cve.CveDataMeta.ID,
+						pp.Sprintf("%v", *item),
+					)
+				}
+			}
+			for _, child := range node.Children {
+				for _, cpe := range child.Cpes {
+					if cpe.Vulnerable {
+						cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+						if err != nil {
+							return nil, err
+						}
+						cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+						cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+						cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+						cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+						nodeCpes = append(nodeCpes, models.Cpe{
+							CpeBase: *cpeBase,
+						})
+						if !checkIfVersionParsable(cpeBase) {
+							return nil, fmt.Errorf(
+								"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
+								item.Cve.CveDataMeta.ID,
+								pp.Sprintf("%v", *item),
+							)
+						}
+					} else {
+						if node.Operator == "AND" {
+							for i, c := range nodeCpes {
+								cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+								if err != nil {
+									return nil, err
+								}
+								cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+								cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+								cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+								cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+								nodeCpes[i].EnvCpes = append(c.EnvCpes, models.EnvCpe{
+									CpeBase: *cpeBase,
+								})
+
+								if !checkIfVersionParsable(cpeBase) {
+									return nil, fmt.Errorf(
+										"Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: Version parse err: %s, Content:%s",
+										item.Cve.CveDataMeta.ID,
+										pp.Sprintf("%v", *item),
+									)
+								}
 							}
 						}
 					}
 				}
 			}
+			cpes = append(cpes, nodeCpes...)
 		}
-		cpes = append(cpes, nodeCpes...)
-	}
 
+	}
 	// Description
 	descs := []models.Description{}
 	for _, desc := range item.Cve.Description.DescriptionData {

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -279,7 +279,7 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 
 	affects := []models.Affect{}
 	cpes := []models.Cpe{}
-	if !c.Conf.IgnoreCPE {
+	if !c.Conf.Light {
 		// Affects
 		for _, vendor := range item.Cve.Affects.Vendor.VendorData {
 			for _, prod := range vendor.Product.ProductData {


### PR DESCRIPTION
# What did you implement:

CPE relate data in NVD JSON feed is too heavy. 
It costs over 2.5GB of memory to fetch and store into DB.

Vuls uses this CPE data only in CPE based scan mode. 
(CPE data never used in OVAL based scan)

I add a mode that does not collect CPE information.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

./go-cve-dictionary fetchnvd -ignore-cpe -last2y

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

