### PR TITLE
Store reference tags

### DIFF
--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -243,6 +243,7 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	for _, r := range item.Cve.References.ReferenceData {
 		ref := models.Reference{
 			Link: r.URL,
+			Tags: strings.Join(r.TAGS, ","),
 		}
 		refs = append(refs, ref)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -260,6 +260,7 @@ type Reference struct {
 	JvnID      uint `json:"-" xml:"-"`
 
 	Source string
+	Tags   string
 	Link   string `sql:"type:text"`
 }
 


### PR DESCRIPTION
This PR enables `go-cve-dictionary` to store reference tags. 
These are stored as a string where each tag is separated by a comma. 