### PR TITLE
Make 'list' command works correctly when fetched feeds exceed 20.

### DIFF
--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -51,11 +51,15 @@ func FetchFeedFiles(reqs []FetchRequest) (results []FetchResult, err error) {
 
 	concurrency := len(reqs)
 	tasks := util.GenWorkers(concurrency)
+	parallelism := 20 / concurrency
+	if parallelism < 1 {
+		parallelism = 1
+	}
 	for range reqs {
 		tasks <- func() {
 			select {
 			case req := <-reqChan:
-				body, err := fetchFile(req, 20/len(reqs))
+				body, err := fetchFile(req, parallelism)
 				if err != nil {
 					errChan <- err
 					return


### PR DESCRIPTION
I fixed a bug that 'list' command fails when fetched feeds exceed 20.

```bash
vuls:~$ go-cve-dictionary list
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2005.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2007.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2006.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2009.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2012.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2017.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2008.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2010.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2011.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2018.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2003.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2013.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2014.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2016.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2019.meta
INFO[10-07|10:56:17] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2004.meta
panic: runtime error: integer divide by zero

goroutine 14 [running]:
github.com/htcat/htcat.(*HtCat).startup(0xc0002699a0, 0x0)
        /home/vuls/go/pkg/mod/github.com/htcat/htcat@v1.0.2/http.go:102 +0x67e
github.com/htcat/htcat.New(0xc0003c2450, 0xc000388f80, 0x0, 0x0)
        /home/vuls/go/pkg/mod/github.com/htcat/htcat@v1.0.2/http.go:154 +0x1a1
github.com/kotakanbe/go-cve-dictionary/fetcher.fetchFile(0x7e1, 0xc0002dcbc0, 0x3c, 0xc000042700, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/vuls/go/src/github.com/kotakanbe/go-cve-dictionary/fetcher/fetcher.go:116 +0x296
github.com/kotakanbe/go-cve-dictionary/fetcher.FetchFeedFiles.func2()
        /home/vuls/go/src/github.com/kotakanbe/go-cve-dictionary/fetcher/fetcher.go:58 +0xfe
github.com/kotakanbe/go-cve-dictionary/util.GenWorkers.func1(0xc000027680)
        /home/vuls/go/src/github.com/kotakanbe/go-cve-dictionary/util/util.go:15 +0x3b
created by github.com/kotakanbe/go-cve-dictionary/util.GenWorkers
        /home/vuls/go/src/github.com/kotakanbe/go-cve-dictionary/util/util.go:13 +0x66
vuls:~$
```
