### PR TITLE
Detect reject CVE in nvd and jvn

### DIFF
--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -175,7 +175,7 @@ func UpdateMeta(driver db.DB, metas []models.FeedMeta) error {
 		meta.LastModifiedDate = meta.LatestLastModifiedDate
 		err := driver.UpsertFeedHash(meta)
 		if err != nil {
-			return fmt.Errorf("Failed to updte meta: %s, err: %s",
+			return fmt.Errorf("Failed to update meta: %s, err: %s",
 				meta.URL, err)
 		}
 	}
@@ -204,10 +204,13 @@ func Fetch(metas []models.FeedMeta) ([]Item, error) {
 			return nil, fmt.Errorf(
 				"Failed to unmarshal. url: %s, err: %s", res.URL, err)
 		}
-		items = append(items, rdf.Items...)
+		for i, item := range rdf.Items {
+			if !(strings.Contains(item.Description, "** 未確定 **") || strings.Contains(item.Description, "** サポート外 **") || strings.Contains(item.Description, "** 削除 **")) {
+				items = append(items, rdf.Items[i])
+			}
+		}
 	}
 	return items, nil
-
 }
 
 // FetchConvert fetches vulnerability information from JVN and convert it to model

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -38,12 +38,28 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 
 	errs := []error{}
 	for _, res := range results {
-		nvd := NvdJSON{}
-		if err = json.Unmarshal(res.Body, &nvd); err != nil {
+		var nvd, nvdIncludeRejectedCve NvdJSON
+		if err = json.Unmarshal(res.Body, &nvdIncludeRejectedCve); err != nil {
 			return nil, fmt.Errorf(
 				"Failed to unmarshal. url: %s, err: %s",
 				res.URL, err)
 		}
+
+		nvd.CveDataType = nvdIncludeRejectedCve.CveDataType
+		nvd.CveDataFormat = nvdIncludeRejectedCve.CveDataFormat
+		nvd.CveDataVersion = nvdIncludeRejectedCve.CveDataVersion
+		nvd.CveDataNumberOfCVEs = nvdIncludeRejectedCve.CveDataNumberOfCVEs
+		nvd.CveDataTimestamp = nvdIncludeRejectedCve.CveDataTimestamp
+
+		// Remove rejected CVEs
+		for i, item := range nvdIncludeRejectedCve.CveItems {
+			for _, description := range item.Cve.Description.DescriptionData {
+				if !(strings.Contains(description.Value, "** REJECT **")) {
+					nvd.CveItems = append(nvd.CveItems, nvdIncludeRejectedCve.CveItems[i])
+				}
+			}
+		}
+
 		cs, err := convert(nvd.CveItems)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
# What did you implement

The rejected CVEs are detected in nvd and jvn when the fetch is executed.
There had unique signatures in the summary, which I used to detect them.
Signature in NVD is ** Reject **.
Signature in JVN is ** 未確定 **, ** サポート外 **, ** 削除 **.

Fixes Vuls issue https://github.com/future-architect/vuls/issues/511

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Before fix
NVD include many rejected CVEs
![image](https://user-images.githubusercontent.com/39241071/103199816-146e5e00-492f-11eb-8325-1a096a01a05d.png)
![image](https://user-images.githubusercontent.com/39241071/103199846-2f40d280-492f-11eb-98be-24a3bbd78c98.png)

** 削除 ** is included in JVN.
![image](https://user-images.githubusercontent.com/39241071/103199067-55657300-492d-11eb-98c6-6982500517a3.png)

## After fix
Rejected CVEs can't count in NVD because succeed to detect.
![image](https://user-images.githubusercontent.com/39241071/103199857-3667e080-492f-11eb-9f07-8a2b4d1b2147.png)

** 削除 ** is not included in JVN.
![image](https://user-images.githubusercontent.com/39241071/103198956-fa338080-492c-11eb-9283-70559d2b2f9b.png)


# Reference

* https://github.com/future-architect/vuls/issues/511

