### PR TITLE
fix(jvn): only logging if invalid cpe format in JVN

### DIFF
--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -332,7 +332,8 @@ func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 		for _, c := range item.Cpes {
 			cpeBase, err := fetcher.ParseCpeURI(c.Value)
 			if err != nil {
-				log.Warnf("Failed to parse CPE URI: %s", c.Value)
+				// logging only
+				log.Infof("Failed to parse CPE URI: %s, %s", c.Value, err)
 				continue
 			}
 			cpes = append(cpes, models.Cpe{

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -294,11 +294,12 @@ func makeJvnURLs(years []int) (urls []string) {
 func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 	var cvss2, cvss3 Cvss
 	for _, cvss := range item.Cvsses {
-		switch cvss.Version {
-		case "2.0":
+		if strings.HasPrefix(cvss.Version, "2") {
 			cvss2 = cvss
-		case "3.0":
+		} else if strings.HasPrefix(cvss.Version, "3") {
 			cvss3 = cvss
+		} else {
+			log.Warnf("Unknown CVSS version format: %s", cvss.Version)
 		}
 	}
 
@@ -331,7 +332,8 @@ func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 		for _, c := range item.Cpes {
 			cpeBase, err := fetcher.ParseCpeURI(c.Value)
 			if err != nil {
-				return nil, err
+				log.Warnf("Failed to parse CPE URI: %s", c.Value)
+				continue
 			}
 			cpes = append(cpes, models.Cpe{
 				CpeBase: *cpeBase,


### PR DESCRIPTION
# What did you implement:

Fixes #180 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
make build; and ./go-cve-dictionary fetchjvn -years -force 2020
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/kotakanbe/go-cve-dictionary github.com/kotakanbe/go-cve-dictionary/commands github.com/kotakanbe/go-cve-dictionary/config github.com/kotakanbe/go-cve-dictionary/db github.com/kotakanbe/go-cve-dictionary/fetcher github.com/kotakanbe/go-cve-dictionary/fetcher/jvn/xml github.com/kotakanbe/go-cve-dictionary/fetcher/nvd github.com/kotakanbe/go-cve-dictionary/fetcher/nvd/json github.com/kotakanbe/go-cve-dictionary/log github.com/kotakanbe/go-cve-dictionary/models github.com/kotakanbe/go-cve-dictionary/server github.com/kotakanbe/go-cve-dictionary/util
echo github.com/kotakanbe/go-cve-dictionary github.com/kotakanbe/go-cve-dictionary/commands github.com/kotakanbe/go-cve-dictionary/config github.com/kotakanbe/go-cve-dictionary/db github.com/kotakanbe/go-cve-dictionary/fetcher github.com/kotakanbe/go-cve-dictionary/fetcher/jvn/xml github.com/kotakanbe/go-cve-dictionary/fetcher/nvd github.com/kotakanbe/go-cve-dictionary/fetcher/nvd/json github.com/kotakanbe/go-cve-dictionary/log github.com/kotakanbe/go-cve-dictionary/models github.com/kotakanbe/go-cve-dictionary/server github.com/kotakanbe/go-cve-dictionary/util | xargs env GO111MODULE=on go vet || exit;
gofmt -d commands/fetchjvn.go; gofmt -d commands/fetchnvd.go; gofmt -d commands/list.go; gofmt -d commands/server.go; gofmt -d config/config.go; gofmt -d config/config_test.go; gofmt -d db/db.go; gofmt -d db/db_test.go; gofmt -d db/rdb.go; gofmt -d db/redis.go; gofmt -d fetcher/fetcher.go; gofmt -d fetcher/jvn/xml/jvn.go; gofmt -d fetcher/nvd/json/nvd.go; gofmt -d fetcher/nvd/util.go; gofmt -d fetcher/nvd/util_test.go; gofmt -d fetcher/util.go; gofmt -d log/log.go; gofmt -d main.go; gofmt -d models/models.go; gofmt -d models/models_test.go; gofmt -d server/server.go; gofmt -d util/util.go;
gofmt -w commands/fetchjvn.go commands/fetchnvd.go commands/list.go commands/server.go config/config.go config/config_test.go db/db.go db/db_test.go db/rdb.go db/redis.go fetcher/fetcher.go fetcher/jvn/xml/jvn.go fetcher/nvd/json/nvd.go fetcher/nvd/util.go fetcher/nvd/util_test.go fetcher/util.go log/log.go main.go models/models.go models/models_test.go server/server.go util/util.go
GO111MODULE=on go build -ldflags "-X 'main.version=v0.5.7' -X 'main.revision=99e9f0d'" -o go-cve-dictionary main.go
EROR[02-26|14:10:12] Failed to create a log file              err="open /var/log/vuls/cve-dictionary.log: permission denied"
INFO[02-26|14:10:12] Fetching... https://jvndb.jvn.jp/ja/feed/checksum.txt 
INFO[02-26|14:10:12] Fetched... https://jvndb.jvn.jp/ja/feed/checksum.txt 
INFO[02-26|14:10:12] Fetching CVE information from JVN. 
INFO[02-26|14:10:12] Fetching... https://jvndb.jvn.jp/ja/rss/years/jvndb_2020.rdf 
INFO[02-26|14:10:12] Fetching... https://jvndb.jvn.jp/ja/rss/jvndb.rdf 
INFO[02-26|14:10:12] Fetching... https://jvndb.jvn.jp/ja/rss/jvndb_new.rdf 
INFO[02-26|14:10:12] Fetched... https://jvndb.jvn.jp/ja/rss/jvndb_new.rdf 
INFO[02-26|14:10:12] Fetched... https://jvndb.jvn.jp/ja/rss/jvndb.rdf 
INFO[02-26|14:10:14] Fetched... https://jvndb.jvn.jp/ja/rss/years/jvndb_2020.rdf 
INFO[02-26|14:10:16] Failed to parse CPE URI: cpe:/a:mitsubishielectric:cpu_ module_logging_configuration_tool, Failed to validate a value: component cannot contain whitespace:: cpu_ module_logging_configuration_tool: Parse error 
INFO[02-26|14:10:16] Failed to parse CPE URI: cpe:/a:mitsubishielectric:cpu_ module_logging_configuration_tool, Failed to validate a value: component cannot contain whitespace:: cpu_ module_logging_configuration_tool: Parse error 
INFO[02-26|14:10:22] Fetched 10613 CVEs 
INFO[02-26|14:10:22] Inserting JVN into DB (sqlite3). 
INFO[02-26|14:10:22] Inserting fetched CVEs... 
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

