### PR TITLE
Use only US-CERT as CERT information in NVD

### DIFF
--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -244,11 +244,6 @@ type CveItem struct {
 	LastModifiedDate string `json:"lastModifiedDate"`
 }
 
-// CertLink is a structure to temporarily store reference URLs.
-type CertLink struct {
-	Link string
-}
-
 // convertToModel converts Nvd JSON to model structure.
 func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	//References
@@ -264,22 +259,19 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	}
 
 	// Certs
-	links := []CertLink{}
+	certs := []models.Cert{}
 	for _, ref := range item.Cve.References.ReferenceData {
-		tag := strings.Join(ref.Tags, " ")
-		if strings.Contains(ref.URL, "ncas/alerts") || strings.Contains(ref.URL, "cas/techalerts") || strings.Contains(tag, "US Government Resource") {
-			if !strings.HasPrefix(ref.URL, "http") || strings.HasSuffix(ref.URL, ".pdf") {
-				continue
-			}
-			links = append(links, CertLink{
-				Link: ref.URL,
+		if !strings.HasPrefix(ref.URL, "http") {
+			continue
+		}
+		if strings.Contains(ref.URL, "us-cert") {
+			ss := strings.Split(ref.URL, "/")
+			title := fmt.Sprintf("US-CERT-%s", ss[len(ss)-1])
+			certs = append(certs, models.Cert{
+				Link:  ref.URL,
+				Title: title,
 			})
 		}
-	}
-
-	certs := []models.Cert{}
-	for _, link := range links {
-		certs = append(certs, models.Cert{Link: link.Link})
 	}
 
 	// Cwes

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -3,14 +3,9 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 
-	"net/http"
-	"net/url"
-
-	"github.com/PuerkitoBio/goquery"
 	"github.com/hashicorp/go-version"
 	"github.com/k0kubun/pp"
 	c "github.com/kotakanbe/go-cve-dictionary/config"
@@ -282,10 +277,9 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 		}
 	}
 
-	certs, err := collectCertLinks(links)
-	if err != nil {
-		return nil,
-			fmt.Errorf("Failed to collect links. err: %s", err)
+	certs := []models.Cert{}
+	for _, link := range links {
+		certs = append(certs, models.Cert{Link: link.Link})
 	}
 
 	// Cwes
@@ -467,84 +461,6 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 			LastModifiedDate: modified,
 		},
 	}, nil
-}
-
-func collectCertLinks(links []CertLink) (certs []models.Cert, err error) {
-	var proxyURL *url.URL
-	httpClient := &http.Client{}
-	if c.Conf.HTTPProxy != "" {
-		if proxyURL, err = url.Parse(c.Conf.HTTPProxy); err != nil {
-			return nil, fmt.Errorf("failed to parse proxy url: %s", err)
-		}
-		httpClient = &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
-	}
-
-	reqChan := make(chan string, len(links))
-	resChan := make(chan models.Cert, len(links))
-	errChan := make(chan error, len(links))
-	defer close(reqChan)
-	defer close(resChan)
-	defer close(errChan)
-
-	go func() {
-		for _, ref := range links {
-			reqChan <- ref.Link
-		}
-	}()
-
-	concurrency := runtime.NumCPU()
-	tasks := util.GenWorkers(concurrency)
-	for _, l := range links {
-		tasks <- func() {
-			url := <-reqChan
-			// log.Debugf("Fetching %s", url)
-
-			req, err := http.NewRequest("GET", url, nil)
-			if err != nil {
-				log.Debugf("Failed to get %s: err: %s", url, err)
-				errChan <- err
-				return
-			}
-
-			res, err := httpClient.Do(req)
-			if err != nil {
-				log.Debugf("Failed to get %s: err: %s", url, err)
-				errChan <- err
-				return
-			}
-			defer res.Body.Close()
-
-			doc, err := goquery.NewDocumentFromReader(res.Body)
-			if err != nil {
-				log.Debugf("Failed to get %s: err: %s", url, err)
-				errChan <- err
-				return
-			}
-			var title string
-			if strings.Contains(l.Link, "kb.cert.org") || strings.Contains(l.Link, "kaspersky.com") {
-				title = doc.Find("title").Text()
-			} else {
-				title = doc.Find("#page-sub-title").Text()
-			}
-			res.Body.Close()
-			resChan <- models.Cert{
-				Title: title,
-				Link:  l.Link,
-			}
-		}
-	}
-
-	timeout := time.After(10 * 30 * time.Second)
-	for range links {
-		select {
-		case res := <-resChan:
-			certs = append(certs, res)
-		case <-errChan:
-		case <-timeout:
-			log.Debugf("timeout fetching")
-		}
-	}
-	return certs, nil
 }
 
 func checkIfVersionParsable(cpeBase *models.CpeBase) bool {


### PR DESCRIPTION
- Use only US-CERT as CERT information.
- Stop scraping CERT title in NVD fetch process, because errors occurred frequently.
