### PR TITLE
fix(fetch-nvd): prevent overwriting with old cve-details on redis

### DIFF
--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -30,6 +31,10 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 		return nil,
 			fmt.Errorf("Failed to fetch. err: %s", err)
 	}
+
+	// The redis-put-process overwrite without referring the last modified date.
+	// Sort so that recent-feed is the last element.
+	sort.Slice(results, func(i, j int) bool { return results[i].URL < results[j].URL })
 
 	errs := []error{}
 	for _, res := range results {


### PR DESCRIPTION
	// The redis-put-process overwrite without referring the last modified date.
	// Sort so that recent-feed is the last element.
	sort.Slice(results, func(i, j int) bool { return results[i].URL < results[j].URL })

```
ubuntu@dev  │tmp  curl -s https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.json.gz | gunzip | jq '.CVE_Items[] | select( .cve.CVE_data_meta.ID == "CVE-2021-29647" ) | .lastModifiedDate'
"2021-04-02T04:15Z"
 ubuntu@dev  │tmp  curl -s https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz | gunzip | jq '.CVE_Items[] | select( .cve.CVE_data_meta.ID == "CVE-2021-29647" ) | .lastModifiedDate'
"2021-04-05T11:38Z"
 ubuntu@dev  │tmp  curl -s https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz | gunzip | jq '.CVE_Items[] | select( .cve.CVE_data_meta.ID == "CVE-2021-29647" ) | .lastModifiedDate'
"2021-04-05T11:38Z"
```