### PR TITLE
fix(cpe): cpe match logic

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.32
+          args: --timeout=10m
           
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/db/db.go
+++ b/db/db.go
@@ -101,60 +101,95 @@ func makeVersionConstraint(dict models.Cpe) string {
 	return strings.Join(constraints, ", ")
 }
 
-func match(uri string, cpe models.Cpe) (bool, error) {
-	specified, err := naming.UnbindURI(uri)
+func match(specifiedURI string, cpeInNvd models.Cpe) (bool, error) {
+	specified, err := naming.UnbindURI(specifiedURI)
 	if err != nil {
 		return false, err
 	}
 
-	wfn, err := naming.UnbindURI(cpe.URI)
+	cpeInNvdWfn, err := naming.UnbindURI(cpeInNvd.URI)
 	if err != nil {
 		return false, errors.Wrap(err, "UnbindURI")
 	}
 
-	if wfn.Get("part") != specified.Get("part") ||
-		wfn.Get("vendor") != specified.Get("vendor") ||
-		wfn.Get("product") != specified.Get("product") {
+	if cpeInNvdWfn.Get("part") != specified.Get("part") ||
+		cpeInNvdWfn.Get("vendor") != specified.Get("vendor") ||
+		cpeInNvdWfn.Get("product") != specified.Get("product") {
 		return false, nil
 	}
 
-	if matching.IsEqual(specified, wfn) {
-		log.Debugf("%s equals %s", specified.String(), cpe.URI)
+	if matching.IsEqual(specified, cpeInNvdWfn) {
+		log.Debugf("%s equals %s", specified.String(), cpeInNvd.URI)
 		return true, nil
 	}
-	ver := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
+	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
 
-	switch ver {
+	switch specifiedVer {
 	case "NA", "ANY":
-		if matching.IsSuperset(wfn, specified) {
-			log.Debugf("%s is superset of %s", cpe.URI, specified.String())
-			return true, nil
-		}
-		if matching.IsSubset(wfn, specified) {
-			log.Debugf("%s is subset of %s", cpe.URI, specified.String())
-			return true, nil
-		}
-
-	default:
-		ver = strings.Replace(ver, `\`, "", -1)
-		v, err := version.NewVersion(ver)
-		if err != nil {
-			log.Debugf("Failed to parse the semver: %s", err)
+		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
 			return false, err
 		}
-		constraintStr := makeVersionConstraint(cpe)
+		return isSuperORSubset(cpeInNvdWfn, specified), nil
+	default:
+		constraintStr := makeVersionConstraint(cpeInNvd)
 		if constraintStr != "" {
 			constraints, err := version.NewConstraint(constraintStr)
 			if err != nil {
-				return false, errors.Wrap(err, "NewConstraint")
+				return false, err
 			}
-			if constraints.Check(v) {
-				log.Debugf("%s satisfies constraints %s", v, constraintStr)
-				return true, nil
+			specifiedVer = strings.Replace(specifiedVer, `\`, "", -1)
+			v, err := version.NewVersion(specifiedVer)
+			if err != nil {
+				log.Debugf("Failed to parse the semver: %s, err: %s", specifiedVer, err)
+				return false, err
 			}
+			if !constraints.Check(v) {
+				return false, nil
+			}
+			log.Debugf("%s satisfies version constraints %s", v, constraintStr)
+
+			if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
+				return false, err
+			}
+			if err := specified.Set(common.AttributeVersion, nil); err != nil {
+				return false, err
+			}
+			return isSuperORSubset(cpeInNvdWfn, specified), nil
 		}
+
+		// If the specified version is not as a range, but as a fixed value
+		//
+		// return true in this case:
+		// - config.toml:  	"cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+		// - AffectedCPEInNVD:    "cpe:/a:apache:cordova:5.1.1",
+		//
+		// In this case, target_sw does not match and returns false
+		// - config.toml:  	"cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+		// - AffectedCPEInNVD:    "cpe:/a:apache:cordova:5.1.1::~~~android~~",
+		if fmt.Sprintf("%s", specified.Get(common.AttributeVersion)) !=
+			fmt.Sprintf("%s", cpeInNvdWfn.Get(common.AttributeVersion)) {
+			return false, nil
+		}
+		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
+			return false, err
+		}
+		if err := specified.Set(common.AttributeVersion, nil); err != nil {
+			return false, err
+		}
+		return isSuperORSubset(cpeInNvdWfn, specified), nil
 	}
-	return false, nil
+}
+
+func isSuperORSubset(source, target common.WellFormedName) bool {
+	if matching.IsSuperset(source, target) {
+		log.Debugf("%s is superset of %s", source.String(), target.String())
+		return true
+	}
+	if matching.IsSubset(source, target) {
+		log.Debugf("%s is subset of %s", source.String(), target.String())
+		return true
+	}
+	return false
 }
 
 func matchExactByAffects(uri string, affects []models.Affect) (bool, error) {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -111,6 +111,7 @@ func TestMakeVersionConstraint(t *testing.T) {
 // move to rdb_test.go
 func TestMatch(t *testing.T) {
 	var testdata = []struct {
+		name  string
 		uri   string
 		cpe   models.Cpe
 		match bool
@@ -121,20 +122,7 @@ func TestMatch(t *testing.T) {
 			uri: "cpe:/a:oracle:vm_virtualbox:5.1.1",
 			cpe: models.Cpe{
 				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox",
-					CpeWFN: models.CpeWFN{
-						Part:            "a",
-						Vendor:          "oracle",
-						Product:         "vm_virtualbox",
-						Version:         "",
-						Update:          "",
-						Edition:         "",
-						Language:        "",
-						SoftwareEdition: "",
-						TargetSW:        "",
-						TargetHW:        "",
-						Other:           "",
-					},
+					URI:                   "cpe:/a:oracle:vm_virtualbox",
 					VersionStartIncluding: "5.1.0",
 					VersionEndExcluding:   "5.1.32",
 				},
@@ -146,12 +134,7 @@ func TestMatch(t *testing.T) {
 			uri: "cpe:/a:oracle:vm_virtualbox:5.0.9",
 			cpe: models.Cpe{
 				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "oracle",
-						Product: "vm_virtualbox",
-					},
+					URI:                   "cpe:/a:oracle:vm_virtualbox",
 					VersionStartIncluding: "5.1.0",
 					VersionEndExcluding:   "5.1.32",
 				},
@@ -163,12 +146,7 @@ func TestMatch(t *testing.T) {
 			uri: "cpe:/a:oracle:vm_virtualbox:5.1.0",
 			cpe: models.Cpe{
 				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "oracle",
-						Product: "vm_virtualbox",
-					},
+					URI:                   "cpe:/a:oracle:vm_virtualbox",
 					VersionStartIncluding: "5.1.0",
 					VersionEndExcluding:   "5.1.32",
 				},
@@ -180,12 +158,7 @@ func TestMatch(t *testing.T) {
 			uri: "cpe:/a:oracle:vm_virtualbox:5.2.32",
 			cpe: models.Cpe{
 				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "oracle",
-						Product: "vm_virtualbox",
-					},
+					URI:                   "cpe:/a:oracle:vm_virtualbox",
 					VersionStartIncluding: "5.1.0",
 					VersionEndExcluding:   "5.1.32",
 				},
@@ -197,12 +170,7 @@ func TestMatch(t *testing.T) {
 			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
 			cpe: models.Cpe{
 				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "oracle",
-						Product: "vm_virtualbox",
-					},
+					URI:                   "cpe:/a:oracle:vm_virtualbox",
 					VersionStartIncluding: "5.1.0",
 					VersionEndExcluding:   "5.1.32",
 				},
@@ -212,82 +180,147 @@ func TestMatch(t *testing.T) {
 		//5
 		{
 			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
-			cpe: models.Cpe{
-				CpeBase: models.CpeBase{
-					URI: "cpe:/a:oracle:vm_virtualbox:5.1.31",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "oracle",
-						Product: "vm_virtualbox",
-						Version: "5.1.31",
-					},
-				},
-			},
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:oracle:vm_virtualbox:5.1.31",
+			}},
 			match: true,
 		},
-		//6 superset
+		//
 		{
-			uri: "cpe:/o:microsoft:windows_7",
-			cpe: models.Cpe{
-				CpeBase: models.CpeBase{
-					URI: "cpe:/o:microsoft:windows_7::sp1",
-					CpeWFN: models.CpeWFN{
-						Part:    "o",
-						Vendor:  "microsoft",
-						Product: "windows_7",
-						Version: "",
-						Update:  "sp1",
-					},
-				},
-			},
-			match: true,
-		},
-		//7 subset
-		{
-			uri: "cpe:/o:microsoft:windows_7::sp2",
-			cpe: models.Cpe{
-				CpeBase: models.CpeBase{
-					URI: "cpe:/o:microsoft:windows_7",
-					CpeWFN: models.CpeWFN{
-						Part:    "o",
-						Vendor:  "microsoft",
-						Product: "windows_7",
-					},
-				},
-			},
+			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:oracle:vm_virtualbox:5.1.31",
+			}},
 			match: true,
 		},
 		{
-			uri: "cpe:/o:microsoft:windows_10",
-			cpe: models.Cpe{
-				CpeBase: models.CpeBase{
-					URI: "cpe:/o:microsoft:windows_10:-",
-					CpeWFN: models.CpeWFN{
-						Part:    "o",
-						Vendor:  "microsoft",
-						Product: "windows_10",
-						Version: "-",
-					},
-				},
-			},
+			name: "superset",
+			uri:  "cpe:/o:microsoft:windows_7",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/o:microsoft:windows_7::sp1",
+			}},
 			match: true,
 		},
-		//9 Cisco Versioning
 		{
-			uri: "cpe:/a:cisco:ios:15.2%282%29eb",
-			cpe: models.Cpe{
-				CpeBase: models.CpeBase{
-					URI: "cpe:/a:cisco:ios:15.2%282%29ec",
-					CpeWFN: models.CpeWFN{
-						Part:    "a",
-						Vendor:  "cisco",
-						Product: "ios",
-						Version: `15\.2\(2\)ec`,
-					},
-				},
-			},
+			name: "subset",
+			uri:  "cpe:/o:microsoft:windows_7::sp2",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/o:microsoft:windows_7",
+			}},
+			match: true,
+		},
+		{
+			name: "subset",
+			uri:  "cpe:/o:microsoft:windows_10",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/o:microsoft:windows_10:-",
+			}},
+			match: true,
+		},
+		{
+			//TODO
+			name: "no semver format",
+			uri:  "cpe:/a:cisco:ios:15.2%282%29eb",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:cisco:ios:15.2%282%29ec",
+			}},
 			match: false,
 			err:   true,
+		},
+		// targetSW
+		{
+			name: "targetSW: 1",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			}},
+			match: true,
+			err:   false,
+		},
+		{
+			name: "targetSW: 2",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1::~~~android~~",
+			}},
+			match: false,
+			err:   false,
+		},
+		{
+			name: "targetSW: 2.1",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.2::~~~android~~",
+			}},
+			match: false,
+			err:   false,
+		},
+		{
+			name: "targetSW: 2.2",
+			uri:  "cpe:/a:apache:cordova:5.1.1",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.2",
+			}},
+			match: false,
+			err:   false,
+		},
+		{
+			name: "targetSW: 2.3",
+			uri:  "cpe:/a:apache:cordova:5.1.1",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1",
+			}},
+			match: true,
+			err:   false,
+		},
+		{
+			name: "targetSW: 3",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1",
+			}},
+			match: true,
+			err:   false,
+		},
+		{
+			name: "targetSW: 4",
+			uri:  "cpe:/a:apache:cordova:::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1",
+			}},
+			match: true,
+			err:   false,
+		},
+		{
+			name: "targetSW: 5",
+			uri:  "cpe:/a:apache:cordova:::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI: "cpe:/a:apache:cordova:5.1.1::~~~android~~",
+			}},
+			match: false,
+			err:   false,
+		},
+		{
+			name: "targetSW: 6",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI:                   "cpe:/a:apache:cordova",
+				VersionStartIncluding: "5.1.0",
+				VersionEndExcluding:   "5.1.2",
+			}},
+			match: true,
+			err:   false,
+		},
+		{
+			name: "targetSW: 7",
+			uri:  "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
+			cpe: models.Cpe{CpeBase: models.CpeBase{
+				URI:                   "cpe:/a:apache:cordova:::~~~android~~",
+				VersionStartIncluding: "5.1.0",
+				VersionEndExcluding:   "5.1.2",
+			}},
+			match: false,
+			err:   false,
 		},
 	}
 
@@ -298,7 +331,7 @@ func TestMatch(t *testing.T) {
 		}
 
 		if tt.match != match {
-			t.Errorf("[%d] expected: %t, actual: %t", i, tt.match, match)
+			t.Errorf("[%d] name: %s, expected: %t, actual: %t", i, tt.name, tt.match, match)
 		}
 	}
 }


### PR DESCRIPTION
# What did you implement:

In the previous implementations, only the following four items were used in CPE match.
- type, vendor, product, version

In order to enable more detailed comparison, I will change the fields other than the above to be used for CPE comparison.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Pass `make test`

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
