### PR TITLE
feat(cpe): Use JVN when NVD is not available in CPE scan

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -7,7 +7,7 @@ import (
 	version "github.com/hashicorp/go-version"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/matching"
@@ -101,15 +101,34 @@ func makeVersionConstraint(dict models.Cpe) string {
 	return strings.Join(constraints, ", ")
 }
 
+func isSamePartVendorProduct(cpeA, cpeB string) (bool, error) {
+	a, err := naming.UnbindURI(cpeA)
+	if err != nil {
+		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeA, err)
+	}
+
+	b, err := naming.UnbindURI(cpeB)
+	if err != nil {
+		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeB, err)
+	}
+
+	if a.Get("part") == b.Get("part") &&
+		a.Get("vendor") == b.Get("vendor") &&
+		a.Get("product") == b.Get("product") {
+		return true, nil
+	}
+	return false, nil
+}
+
 func match(specifiedURI string, cpeInNvd models.Cpe) (bool, error) {
 	specified, err := naming.UnbindURI(specifiedURI)
 	if err != nil {
-		return false, err
+		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", specifiedURI, err)
 	}
 
 	cpeInNvdWfn, err := naming.UnbindURI(cpeInNvd.URI)
 	if err != nil {
-		return false, errors.Wrap(err, "UnbindURI")
+		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeInNvd.URI, err)
 	}
 
 	if cpeInNvdWfn.Get("part") != specified.Get("part") ||

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -377,21 +377,19 @@ func (r *RDBDriver) getMatchingCpes(uri string,
 				err, uri, cpe.ID, cpe)
 
 			// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
-			if cpe.NvdJSONID != 0 {
-				affects, err := getAffectsFunc(cpe.NvdJSONID)
-				if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
-					return nil, err
-				}
-
-				ok, err := matchExactByAffects(uri, affects)
-				if err != nil {
-					return nil, err
-				}
-				if ok {
-					matchedCpes = append(matchedCpes, cpe)
-				}
-				checkedNvdDBIDs[cpe.NvdJSONID] = true
+			affects, err := getAffectsFunc(cpe.NvdJSONID)
+			if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, err
 			}
+
+			ok, err := matchExactByAffects(uri, affects)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				matchedCpes = append(matchedCpes, cpe)
+			}
+			checkedNvdDBIDs[cpe.NvdJSONID] = true
 		} else if match {
 			matchedCpes = append(matchedCpes, cpe)
 		}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -510,7 +510,7 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		return nil, err
 	}
 
-	details := make([]models.CveDetail, len(cveDetails))
+	details := []models.CveDetail{}
 	for _, d := range cveDetails {
 		details = append(details, d)
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -352,14 +353,92 @@ func (r *RDBDriver) CloseDB() (err error) {
 }
 
 // getMatchingCpes returns matching CPEs  by pseudo-CPE
-func (r *RDBDriver) getMatchingCpes(uri string) ([]models.Cpe, error) {
+func (r *RDBDriver) getMatchingCpes(uri string,
+	getCpesByVendorProductFunc func(string) ([]models.Cpe, error),
+	getAffectsFunc func(uint) ([]models.Affect, error),
+) ([]models.Cpe, error) {
+	cpes, err := getCpesByVendorProductFunc(uri)
+	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
 
-	// parse wfn, get vendor, product
+	matchedCpes := []models.Cpe{}
+	checkedNvdDBIDs := map[uint]bool{}
+	for _, cpe := range cpes {
+		if cpe.NvdJSONID == 0 {
+			continue
+		}
+		if _, ok := checkedNvdDBIDs[cpe.NvdJSONID]; ok {
+			continue
+		}
+		match, err := match(uri, cpe)
+		if err != nil {
+			log.Debugf("Failed to compare the version:%s %s cpe_id:%d %#v",
+				err, uri, cpe.ID, cpe)
+
+			// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
+			if cpe.NvdJSONID != 0 {
+				affects, err := getAffectsFunc(cpe.NvdJSONID)
+				if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, err
+				}
+
+				ok, err := matchExactByAffects(uri, affects)
+				if err != nil {
+					return nil, err
+				}
+				if ok {
+					matchedCpes = append(matchedCpes, cpe)
+				}
+				checkedNvdDBIDs[cpe.NvdJSONID] = true
+			}
+		} else if match {
+			matchedCpes = append(matchedCpes, cpe)
+		}
+	}
+
+	// CPE that exists only in JVN is also detected.
+	// There is a possibility of false positives since the JVN does not contain version information.
+	jvnCpes := []models.Cpe{}
+	for _, cpe := range cpes {
+		if cpe.JvnID == 0 {
+			continue
+		}
+		ok, err := isSamePartVendorProduct(uri, cpe.URI)
+		if err != nil {
+			continue
+		}
+		if ok {
+			jvnCpes = append(matchedCpes, cpe)
+		}
+	}
+
+	// If NVD has data of the same `type`, `verndor`, and `product`, NVD is used in priority.
+	// Because NVD has version information, but JVN does not.
+	for _, jvnCpe := range jvnCpes {
+		found := false
+		for _, cpe := range cpes {
+			if cpe.NvdJSONID == 0 {
+				continue
+			}
+			ok, err := isSamePartVendorProduct(jvnCpe.URI, cpe.URI)
+			if err != nil || ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			matchedCpes = append(matchedCpes, jvnCpe)
+		}
+	}
+	return matchedCpes, nil
+}
+
+func (r *RDBDriver) getCPEsByVendorProduct(uri string) ([]models.Cpe, error) {
 	specified, err := naming.UnbindURI(uri)
 	if err != nil {
 		return nil, err
 	}
-	// select from cpe by vendor, product
 	cpes := []models.Cpe{}
 	err = r.conn.Where(&models.Cpe{
 		CpeBase: models.CpeBase{
@@ -371,47 +450,21 @@ func (r *RDBDriver) getMatchingCpes(uri string) ([]models.Cpe, error) {
 	if err != nil && err != gorm.ErrRecordNotFound {
 		return nil, err
 	}
+	return cpes, nil
+}
 
-	log.Debugf("specified: %s", uri)
-	filtered := []models.Cpe{}
-	checkedIDs := map[uint]bool{}
-	for _, cpe := range cpes {
-		match, err := match(uri, cpe)
-		if err != nil {
-			log.Debugf("Failed to compare the version:%s %s cpe_id:%d %#v",
-				err, uri, cpe.ID, cpe)
-
-			// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
-			if cpe.NvdJSONID != 0 {
-				if _, ok := checkedIDs[cpe.NvdJSONID]; ok {
-					continue
-				}
-				affects := []models.Affect{}
-				result := r.conn.Where(&models.Affect{NvdJSONID: cpe.NvdJSONID}).Find(&affects)
-				if result.Error != nil && result.Error != gorm.ErrRecordNotFound {
-					return nil, result.Error
-				}
-
-				ok, err := matchExactByAffects(uri, affects)
-				if err != nil {
-					return nil, err
-				}
-				if ok {
-					filtered = append(filtered, cpe)
-				}
-				checkedIDs[cpe.NvdJSONID] = true
-			}
-		} else if match {
-			filtered = append(filtered, cpe)
-		}
+func (r *RDBDriver) getAffects(nvdID uint) ([]models.Affect, error) {
+	affects := []models.Affect{}
+	result := r.conn.Where(&models.Affect{NvdJSONID: nvdID}).Find(&affects)
+	if result.Error != nil && result.Error != gorm.ErrRecordNotFound {
+		return nil, result.Error
 	}
-
-	return filtered, nil
+	return affects, nil
 }
 
 // GetCveIDsByCpeURI Select Cve Ids by by pseudo-CPE
 func (r *RDBDriver) GetCveIDsByCpeURI(uri string) ([]string, error) {
-	filtered, err := r.getMatchingCpes(uri)
+	filtered, err := r.getMatchingCpes(uri, r.getCPEsByVendorProduct, r.getAffects)
 	if err != nil {
 		return nil, err
 	}
@@ -457,13 +510,9 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		return nil, err
 	}
 
-	// Convert from map to array
 	details := make([]models.CveDetail, len(cveDetails))
-	i := 0
 	for _, d := range cveDetails {
-		details[i] = d
-		i++
-		log.Debugf("%s", d.CveID)
+		details = append(details, d)
 	}
 	return details, nil
 }

--- a/db/rdb_test.go
+++ b/db/rdb_test.go
@@ -1,0 +1,185 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/kotakanbe/go-cve-dictionary/models"
+)
+
+func TestRDBDriver_getMatchingCpes(t *testing.T) {
+	nvdRangeCpe := models.Cpe{
+		NvdJSONID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+			VersionStartIncluding: "0.0.1",
+			VersionEndIncluding:   "2.0.0",
+		},
+	}
+	nvdNonSemVerCpe := models.Cpe{
+		NvdJSONID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+			VersionStartIncluding: "hoge",
+			VersionEndIncluding:   "hoge",
+		},
+	}
+	jvnCpe := models.Cpe{
+		JvnID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+		},
+	}
+
+	type args struct {
+		uri                        string
+		getCpesByVendorProductFunc func(string) ([]models.Cpe, error)
+		getAffects                 func(uint) ([]models.Affect, error)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []models.Cpe
+		wantErr bool
+	}{
+		{
+			name: "nvd range match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdRangeCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) { panic("not implemented") },
+			},
+			want:    []models.Cpe{nvdRangeCpe},
+			wantErr: false,
+		},
+		{
+			name: "nvd range not match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:3.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdRangeCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) { panic("not implemented") },
+			},
+			want:    []models.Cpe{},
+			wantErr: false,
+		},
+		{
+			name: "nvd affects match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdNonSemVerCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) {
+					return []models.Affect{
+						{
+							NvdJSONID: 1,
+							Vendor:    "qualcomm",
+							Product:   "qcs605_firmware",
+							Version:   "1.0.0",
+						},
+					}, nil
+				},
+			},
+			want:    []models.Cpe{nvdNonSemVerCpe},
+			wantErr: false,
+		},
+		{
+			name: "nvd affects not match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdNonSemVerCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) {
+					return []models.Affect{
+						{
+							NvdJSONID: 1,
+							Vendor:    "qualcomm",
+							Product:   "qcs605_firmware",
+							Version:   "1.0.1",
+						},
+					}, nil
+				},
+			},
+			want:    []models.Cpe{},
+			wantErr: false,
+		},
+		{
+			name: "jvn match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{jvnCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) {
+					return nil, nil
+				},
+			},
+			want:    []models.Cpe{jvnCpe},
+			wantErr: false,
+		},
+		{
+			name: "NVD has priority over JVN",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:3.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdRangeCpe, jvnCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) {
+					return nil, nil
+				},
+			},
+			want:    []models.Cpe{},
+			wantErr: false,
+		},
+		{
+			name: "NVD has priority over JVN",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				getCpesByVendorProductFunc: func(string) ([]models.Cpe, error) {
+					return []models.Cpe{nvdRangeCpe, jvnCpe}, nil
+				},
+				getAffects: func(uint) ([]models.Affect, error) {
+					return nil, nil
+				},
+			},
+			want:    []models.Cpe{nvdRangeCpe},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RDBDriver{}
+			got, err := r.getMatchingCpes(tt.args.uri, tt.args.getCpesByVendorProductFunc, tt.args.getAffects)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RDBDriver.getMatchingCpes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RDBDriver.getMatchingCpes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/db/redis.go
+++ b/db/redis.go
@@ -184,7 +184,6 @@ func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, error) {
 
 // GetByCpeURI Select Cve information from DB.
 func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
-	ctx := context.Background()
 	specified, err := naming.UnbindURI(uri)
 	if err != nil {
 		return nil, err
@@ -194,7 +193,7 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	key := fmt.Sprintf("%s%s::%s", hashKeyPrefix, vendor, product)
 
 	var result *redis.StringSliceCmd
-	if result = r.conn.ZRange(ctx, key, 0, -1); result.Err() != nil {
+	if result = r.conn.ZRange(context.Background(), key, 0, -1); result.Err() != nil {
 		return nil, result.Err()
 	}
 
@@ -223,22 +222,16 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 }
 
 func matchCpe(uri string, cve *models.CveDetail) (bool, error) {
-	cpes := []models.Cpe{}
+	nvdCpes := []models.Cpe{}
 	if cve.NvdJSON != nil {
-		cpes = append(cpes, cve.NvdJSON.Cpes...)
+		nvdCpes = append(nvdCpes, cve.NvdJSON.Cpes...)
 	}
-	if cve.Jvn != nil {
-		cpes = append(cpes, cve.Jvn.Cpes...)
-	}
-	for _, cpe := range cpes {
+	for _, cpe := range nvdCpes {
 		match, err := match(uri, cpe)
 		if err != nil {
 			log.Debugf("Failed to match: %s", err)
 
 			// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
-			if cve.NvdJSON == nil {
-				continue
-			}
 			ok, err := matchExactByAffects(uri, cve.NvdJSON.Affects)
 			if err != nil {
 				return false, err
@@ -248,6 +241,35 @@ func matchCpe(uri string, cve *models.CveDetail) (bool, error) {
 			}
 			continue
 		} else if match {
+			return true, nil
+		}
+	}
+
+	if cve.Jvn == nil {
+		return false, nil
+	}
+
+	for _, cpe := range cve.Jvn.Cpes {
+		found := false
+		for _, nvdCpe := range nvdCpes {
+			ok, err := isSamePartVendorProduct(nvdCpe.URI, cpe.URI)
+			if err != nil {
+				continue
+			}
+			if ok {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+
+		ok, err := isSamePartVendorProduct(uri, cpe.URI)
+		if err != nil {
+			continue
+		}
+		if ok {
 			return true, nil
 		}
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -245,11 +245,15 @@ func matchCpe(uri string, cve *models.CveDetail) (bool, error) {
 		}
 	}
 
+	// CPE that exists only in JVN is also detected.
+	// There is a possibility of false positives since the JVN does not contain version information.
 	if cve.Jvn == nil {
 		return false, nil
 	}
 
 	for _, cpe := range cve.Jvn.Cpes {
+		// If NVD has data of the same `type`, `verndor`, and `product`, NVD is used in priority.
+		// Because NVD has version information, but JVN does not.
 		found := false
 		for _, nvdCpe := range nvdCpes {
 			ok, err := isSamePartVendorProduct(nvdCpe.URI, cpe.URI)

--- a/db/redis_test.go
+++ b/db/redis_test.go
@@ -1,0 +1,181 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/kotakanbe/go-cve-dictionary/models"
+)
+
+func Test_matchCpe(t *testing.T) {
+	nvdRangeCpe := models.Cpe{
+		NvdJSONID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+			VersionStartIncluding: "0.0.1",
+			VersionEndIncluding:   "2.0.0",
+		},
+	}
+	nvdNonSemVerCpe := models.Cpe{
+		NvdJSONID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+			VersionStartIncluding: "hoge",
+			VersionEndIncluding:   "hoge",
+		},
+	}
+	jvnCpe := models.Cpe{
+		JvnID: 1,
+		CpeBase: models.CpeBase{
+			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			CpeWFN: models.CpeWFN{
+				Part:    "o",
+				Vendor:  "qualcomm",
+				Product: "qcs605_firmware",
+			},
+		},
+	}
+	type args struct {
+		uri string
+		cve *models.CveDetail
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "nvd range match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdRangeCpe},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "nvd range not match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:3.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdRangeCpe},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "nvd affect match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdNonSemVerCpe},
+						Affects: []models.Affect{
+							{
+								Vendor:  "qualcomm",
+								Product: "qcs605_firmware",
+								Version: "1.0.0",
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "nvd affects not match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdNonSemVerCpe},
+						Affects: []models.Affect{
+							{
+								Vendor:  "qualcomm",
+								Product: "qcs605_firmware",
+								Version: "1.0.1",
+							},
+						},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "jvn match",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				cve: &models.CveDetail{
+					Jvn: &models.Jvn{
+						Cpes: []models.Cpe{jvnCpe},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "NVD has priority over JVN",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:3.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdRangeCpe},
+					},
+					Jvn: &models.Jvn{
+						Cpes: []models.Cpe{jvnCpe},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "NVD has priority over JVN",
+			args: args{
+				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				cve: &models.CveDetail{
+					NvdJSON: &models.NvdJSON{
+						Cpes: []models.Cpe{nvdRangeCpe},
+					},
+					Jvn: &models.Jvn{
+						Cpes: []models.Cpe{jvnCpe},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := matchCpe(tt.args.uri, tt.args.cve)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("matchCpe() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("matchCpe() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kotakanbe/go-cve-dictionary
 
-go 1.15
+go 1.16
 
 require (
 	github.com/PuerkitoBio/goquery v1.6.1
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mattn/go-sqlite3 v1.14.6
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,7 +42,6 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -170,9 +169,7 @@ google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
-google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/models/models.go
+++ b/models/models.go
@@ -145,6 +145,14 @@ type CveDetail struct {
 	Jvn     *Jvn     `json:",omitempty"`
 }
 
+func (c CveDetail) IsNvd() bool {
+	return c.NvdJSON != nil && c.NvdJSON.ID != 0
+}
+
+func (c CveDetail) IsJvn() bool {
+	return c.Jvn != nil && c.Jvn.ID != 0
+}
+
 // NvdJSON is a struct of NVD JSON
 // https://scap.nist.gov/schema/nvd/feed/0.1/nvd_cve_feed_json_0.1_beta.schema
 type NvdJSON struct {

--- a/models/models.go
+++ b/models/models.go
@@ -145,10 +145,12 @@ type CveDetail struct {
 	Jvn     *Jvn     `json:",omitempty"`
 }
 
+// IsNvd returns true if NVD contents
 func (c CveDetail) IsNvd() bool {
 	return c.NvdJSON != nil && c.NvdJSON.ID != 0
 }
 
+// IsJvn returns true if JVN contents
 func (c CveDetail) IsJvn() bool {
 	return c.Jvn != nil && c.Jvn.ID != 0
 }


### PR DESCRIPTION
# What did you implement:

Data sources such as JVN is defined the country's specific software as `affected software list`.
In order to detect vulnerabilities in those software, JVN should also be used as a vulnerability DB for CPE scanning, with the aim of complementing the information in NVD.
However, JVN has the problem that affected `versions` is not defined in machine-readable format ;)

In order to minimize false positives, the following methods are used for detection.

- When the same vendor and product are defined in NVD and JVN, NVD will be used.
- When the same vendor and product are **not** defined in NVD, JVN is used.

All the CVEs detected by JVN is detected by the VENDOR and PRODUCT match. 
Note that versions are not compared, so there are false positives.

If you want to use only NVD information for detection, do not fetch JVN; if you do not fetch JVN, use only NVD.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

test cases added

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES