### PR TITLE
feat(fetcher/nvd): control the concurrency when convert

### DIFF
--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -182,8 +182,17 @@ func UpdateMeta(driver db.DB, metas []models.FeedMeta) error {
 	return nil
 }
 
-// Fetch fetches vulnerability information from JVN and convert it to model
-func Fetch(metas []models.FeedMeta) ([]Item, error) {
+// FetchConvert fetches vulnerability information from JVN and convert it to model
+func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) {
+	items, err := fetch(metas)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(items)
+}
+
+func fetch(metas []models.FeedMeta) ([]Item, error) {
 	reqs := []fetcher.FetchRequest{}
 	for _, meta := range metas {
 		reqs = append(reqs, fetcher.FetchRequest{
@@ -213,19 +222,48 @@ func Fetch(metas []models.FeedMeta) ([]Item, error) {
 	return items, nil
 }
 
-// FetchConvert fetches vulnerability information from JVN and convert it to model
-func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) {
-	items, err := Fetch(metas)
-	if err != nil {
-		return nil, err
+func convert(items []Item) (cves []models.CveDetail, err error) {
+	reqChan := make(chan Item, len(items))
+	resChan := make(chan []models.CveDetail, len(items))
+	errChan := make(chan error)
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	go func() {
+		for _, item := range items {
+			reqChan <- item
+		}
+	}()
+
+	concurrency := runtime.NumCPU() + 2
+	tasks := util.GenWorkers(concurrency)
+	for range items {
+		tasks <- func() {
+			req := <-reqChan
+			cves, err := convertToModel(&req)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			resChan <- cves
+		}
 	}
 
-	for _, item := range items {
-		cs, err := convertToModel(item)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to convertToModel. err: %s", err)
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range items {
+		select {
+		case res := <-resChan:
+			cves = append(cves, res...)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
 		}
-		cves = append(cves, cs...)
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
 	}
 	return cves, nil
 }
@@ -252,8 +290,8 @@ func makeJvnURLs(years []int) (urls []string) {
 	return
 }
 
-// ConvertJvn converts Jvn structure(got from JVN) to model structure.
-func convertToModel(item Item) (cves []models.CveDetail, err error) {
+// convertToModel converts Jvn structure(got from JVN) to model structure.
+func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 	var cvss2, cvss3 Cvss
 	for _, cvss := range item.Cvsses {
 		if strings.HasPrefix(cvss.Version, "2") {
@@ -314,7 +352,7 @@ func convertToModel(item Item) (cves []models.CveDetail, err error) {
 		return nil, err
 	}
 
-	cveIDs := getCveIDs(item)
+	cveIDs := getCveIDs(*item)
 	if len(cveIDs) == 0 {
 		log.Debugf("No CveIDs in references. JvnID: %s, Link: %s",
 			item.Identifier, item.Link)

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -219,51 +219,13 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 	if err != nil {
 		return nil, err
 	}
-	return convert(items)
-}
 
-func convert(items []Item) (cves []models.CveDetail, err error) {
-	reqChan := make(chan Item, len(items))
-	resChan := make(chan []models.CveDetail, len(items))
-	errChan := make(chan error)
-	defer close(reqChan)
-	defer close(resChan)
-	defer close(errChan)
-
-	go func() {
-		for _, item := range items {
-			reqChan <- item
+	for _, item := range items {
+		cs, err := convertToModel(item)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convertToModel. err: %s", err)
 		}
-	}()
-
-	concurrency := runtime.NumCPU() + 2
-	tasks := util.GenWorkers(concurrency)
-	for range items {
-		tasks <- func() {
-			req := <-reqChan
-			cves, err := convertToModel(&req)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			resChan <- cves
-		}
-	}
-
-	errs := []error{}
-	timeout := time.After(10 * 60 * time.Second)
-	for range items {
-		select {
-		case res := <-resChan:
-			cves = append(cves, res...)
-		case err := <-errChan:
-			errs = append(errs, err)
-		case <-timeout:
-			return nil, fmt.Errorf("Timeout Fetching")
-		}
-	}
-	if 0 < len(errs) {
-		return nil, fmt.Errorf("%s", errs)
+		cves = append(cves, cs...)
 	}
 	return cves, nil
 }
@@ -291,7 +253,7 @@ func makeJvnURLs(years []int) (urls []string) {
 }
 
 // ConvertJvn converts Jvn structure(got from JVN) to model structure.
-func convertToModel(item *Item) (cves []models.CveDetail, err error) {
+func convertToModel(item Item) (cves []models.CveDetail, err error) {
 	var cvss2, cvss3 Cvss
 	for _, cvss := range item.Cvsses {
 		if strings.HasPrefix(cvss.Version, "2") {
@@ -352,7 +314,7 @@ func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 		return nil, err
 	}
 
-	cveIDs := getCveIDs(*item)
+	cveIDs := getCveIDs(item)
 	if len(cveIDs) == 0 {
 		log.Debugf("No CveIDs in references. JvnID: %s, Link: %s",
 			item.Identifier, item.Link)

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -268,28 +268,6 @@ func convert(items []Item) (cves []models.CveDetail, err error) {
 	return cves, nil
 }
 
-func makeJvnURLs(years []int) (urls []string) {
-	latestFeeds := []string{
-		"http://jvndb.jvn.jp/ja/rss/jvndb_new.rdf",
-		"http://jvndb.jvn.jp/ja/rss/jvndb.rdf",
-	}
-
-	if len(years) == 0 {
-		return latestFeeds
-	}
-
-	urlFormat := "http://jvndb.jvn.jp/ja/rss/years/jvndb_%d.rdf"
-	for _, year := range years {
-		urls = append(urls, fmt.Sprintf(urlFormat, year))
-
-		thisYear := time.Now().Year()
-		if year == thisYear {
-			urls = append(urls, latestFeeds...)
-		}
-	}
-	return
-}
-
 // convertToModel converts Jvn structure(got from JVN) to model structure.
 func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 	var cvss2, cvss3 Cvss

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -17,6 +17,15 @@ import (
 
 // FetchConvert Fetch CVE vulnerability information from NVD
 func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) {
+	items, err := fetch(metas)
+	if err != nil {
+		return nil, err
+	}
+
+	return convert(items)
+}
+
+func fetch(metas []models.FeedMeta) ([]CveItem, error) {
 	reqs := []fetcher.FetchRequest{}
 	for _, meta := range metas {
 		reqs = append(reqs, fetcher.FetchRequest{
@@ -35,7 +44,7 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 	// Sort so that recent-feed is the last element.
 	sort.Slice(results, func(i, j int) bool { return results[i].URL < results[j].URL })
 
-	errs := []error{}
+	items := []CveItem{}
 	for _, res := range results {
 		var nvd, nvdIncludeRejectedCve NvdJSON
 		if err = json.Unmarshal(res.Body, &nvdIncludeRejectedCve); err != nil {
@@ -59,16 +68,10 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 			}
 		}
 
-		cs, err := convert(nvd.CveItems)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		cves = append(cves, cs...)
+		items = append(items, nvd.CveItems...)
 	}
-	if 0 < len(errs) {
-		return nil, fmt.Errorf("%s", errs)
-	}
-	return cves, nil
+
+	return items, nil
 }
 
 func convert(items []CveItem) (cves []models.CveDetail, err error) {

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
 	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
-	"github.com/kotakanbe/go-cve-dictionary/util"
 )
 
 // FetchConvert Fetch CVE vulnerability information from NVD
@@ -73,47 +72,12 @@ func FetchConvert(metas []models.FeedMeta) (cves []models.CveDetail, err error) 
 }
 
 func convert(items []CveItem) (cves []models.CveDetail, err error) {
-	reqChan := make(chan CveItem, len(items))
-	resChan := make(chan *models.CveDetail, len(items))
-	errChan := make(chan error, len(items))
-	defer close(reqChan)
-	defer close(resChan)
-	defer close(errChan)
-
-	go func() {
-		for _, item := range items {
-			reqChan <- item
+	for _, item := range items {
+		cve, err := convertToModel(&item)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convertToModel. err: %s", err)
 		}
-	}()
-
-	concurrency := 10
-	tasks := util.GenWorkers(concurrency)
-	for range items {
-		tasks <- func() {
-			req := <-reqChan
-			cve, err := convertToModel(&req)
-			if err != nil {
-				errChan <- err
-				return
-			}
-			resChan <- cve
-		}
-	}
-
-	errs := []error{}
-	timeout := time.After(10 * 60 * time.Second)
-	for range items {
-		select {
-		case res := <-resChan:
-			cves = append(cves, *res)
-		case err := <-errChan:
-			errs = append(errs, err)
-		case <-timeout:
-			return nil, fmt.Errorf("Timeout Fetching")
-		}
-	}
-	if 0 < len(errs) {
-		return nil, fmt.Errorf("%s", errs)
+		cves = append(cves, *cve)
 	}
 	return cves, nil
 }

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -3,6 +3,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/kotakanbe/go-cve-dictionary/fetcher"
 	"github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
+	"github.com/kotakanbe/go-cve-dictionary/util"
 )
 
 // FetchConvert Fetch CVE vulnerability information from NVD
@@ -75,12 +77,47 @@ func fetch(metas []models.FeedMeta) ([]CveItem, error) {
 }
 
 func convert(items []CveItem) (cves []models.CveDetail, err error) {
-	for _, item := range items {
-		cve, err := convertToModel(&item)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to convertToModel. err: %s", err)
+	reqChan := make(chan CveItem, len(items))
+	resChan := make(chan *models.CveDetail, len(items))
+	errChan := make(chan error, len(items))
+	defer close(reqChan)
+	defer close(resChan)
+	defer close(errChan)
+
+	go func() {
+		for _, item := range items {
+			reqChan <- item
 		}
-		cves = append(cves, *cve)
+	}()
+
+	concurrency := runtime.NumCPU() + 2
+	tasks := util.GenWorkers(concurrency)
+	for range items {
+		tasks <- func() {
+			req := <-reqChan
+			cve, err := convertToModel(&req)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			resChan <- cve
+		}
+	}
+
+	errs := []error{}
+	timeout := time.After(10 * 60 * time.Second)
+	for range items {
+		select {
+		case res := <-resChan:
+			cves = append(cves, *res)
+		case err := <-errChan:
+			errs = append(errs, err)
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout Fetching")
+		}
+	}
+	if 0 < len(errs) {
+		return nil, fmt.Errorf("%s", errs)
 	}
 	return cves, nil
 }


### PR DESCRIPTION
# What did you implement:
~~Remove the goroutine speedup in convert, as it seems to have little effect on the complexity of the code.~~

~~I rewrote the goroutine in the convert part of NVD and JVN to a simple for. JVN is slower and NVD is faster, probably because JVN uses goroutine in the following part:`collectCertLinks` to access links.~~
~~https://github.com/MaineK00n/go-cve-dictionary/blob/c2acd34f77a7ab377701870885d706126e982c03/fetcher/jvn/xml/jvn.go#L301~~

~~Therefore, I changed only NVD to a simple for loop.~~

In convert, set the appropriate concurrency for goroutine.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## NVD
// upstream/master: 21s
```console
$ go-cve-dictionary fetchnvd --last2y
INFO[07-15|09:23:24] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.meta 
INFO[07-15|09:23:28] Fetched... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz
INFO[07-15|09:23:45] Fetched 26034 CVEs
```
// PR: 6s
```console
$ go-cve-dictionary fetchnvd --last2y 
INFO[07-16|06:54:06] Fetching... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.meta 
INFO[07-16|06:54:10] Fetched... https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2020.json.gz 
INFO[07-16|06:54:16] Fetched 26244 CVEs
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
