### PR TITLE
feat(redis): add expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ For the first time, run the blow command to fetch data for entire period. (It ta
   -debug-sql
     	SQL debug mode
   -expire uint
-    	timeout to set for Redis keys
+    	timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -force
     	Force update
   -http-proxy string
@@ -358,7 +358,7 @@ fetchjvn:
   -debug-sql
     	SQL debug mode
   -expire uint
-    	timeout to set for Redis keys
+    	timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -force
     	Force update
   -http-proxy string

--- a/README.md
+++ b/README.md
@@ -250,45 +250,56 @@ Use "go-cve-dictionary flags" for a list of top-level flags
 ```bash
 $ go-cve-dictionary fetchnvd -help
 fetchnvd:
-        fetchnvd
-                [-latest]
-                [-last2y]
-                [-years] 2015 2016 ...
-                [-dbtype=mysql|postgres|sqlite3|redis]
-                [-dbpath=$PWD/cve.sqlite3 or connection string]
-                [-http-proxy=http://192.168.0.1:8080]
-                [-debug]
-                [-debug-sql]
-                [-quiet]
-                [-log-dir=/path/to/log]
-                [-log-json]
+	fetchnvd
+		[-latest]
+		[-last2y]
+		[-years] 2015 2016 ...
+		[-dbtype=mysql|postgres|sqlite3|redis]
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-quiet]
+		[-log-to-file]
+		[-log-dir=/path/to/log]
+		[-log-json]
+		[-light]
+		[-force]
+		[-expire]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in `seq 2002 $(date +"%Y")`; do go-cve-dictionary fetchnvd -years $i; done
 
   -dbpath string
-        /path/to/sqlite3 or SQL connection string (default "/Users/kanbe/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3")
+    	/path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
   -dbtype string
-        Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
+    	Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
   -debug
-        debug mode
+    	debug mode
   -debug-sql
-        SQL debug mode
+    	SQL debug mode
+  -expire uint
+    	timeout to set for Redis keys
+  -force
+    	Force update
   -http-proxy string
-        http://proxy-url:port (default: empty)
+    	http://proxy-url:port (default: empty)
   -last2y
-        Refresh NVD data in the last two years recent and modified feeds
+    	Refresh NVD data in the last two years recent and modified feeds
   -latest
-        Refresh recent and modified feeds
+    	Refresh recent and modified feeds
+  -light
+    	Don't collect *HEAVY* CPE relate data
   -log-dir string
-        /path/to/log (default "/var/log/vuls")
+    	/path/to/log (default "/var/log/vuls")
   -log-json
-        output log as JSON
+    	output log as JSON
+  -log-to-file
+    	output log to file
   -quiet
-        quiet mode (no output)
+    	quiet mode (no output)
   -years
-        Refresh NVD data of specific years
-
+    	Refresh NVD data of specific years
 ```
 
 - Fetch data for entire period.
@@ -322,42 +333,52 @@ For the first time, run the blow command to fetch data for entire period. (It ta
 ```bash
 $ go-cve-dictionary fetchjvn -h
 fetchjvn:
-        fetchjvn
-                [-latest]
-                [-last2y]
-                [-years] 1998 1999 ...
-                [-dbpath=$PWD/cve.sqlite3 or connection string]
-                [-dbtype=mysql|postgres|sqlite3|redis]
-                [-http-proxy=http://192.168.0.1:8080]
-                [-debug]
-                [-debug-sql]
-                [-quiet]
-                [-log-dir=/path/to/log]
-                [-log-json]
-
+	fetchjvn
+		[-latest]
+		[-last2y]
+		[-years] 1998 1999 ...
+		[-dbpath=$PWD/cve.sqlite3 or connection string]
+		[-dbtype=mysql|postgres|sqlite3|redis]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-quiet]
+		[-log-to-file]
+		[-log-dir=/path/to/log]
+		[-log-json]
+		[-light]
+		[-force]
+		[-expire]
   -dbpath string
-        /path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
+    	/path/to/sqlite3 or SQL connection string (default "$PWD/cve.sqlite3")
   -dbtype string
-        Database type to store data in (sqlite3, mysql, postgres or redis supported) (default "sqlite3")
+    	Database type to store data in (sqlite3,  mysql, postgres or redis supported) (default "sqlite3")
   -debug
-        debug mode
+    	debug mode
   -debug-sql
-        SQL debug mode
+    	SQL debug mode
+  -expire uint
+    	timeout to set for Redis keys
+  -force
+    	Force update
   -http-proxy string
-        http://proxy-url:port (default: empty)
+    	http://proxy-url:port (default: empty)
   -last2y
-        Refresh JVN data in the last two years.
+    	Refresh JVN data in the last two years.
   -latest
-        Refresh JVN data for latest.
-  -quiet
-        quiet mode (no output)
+    	Refresh JVN data for latest.
+  -light
+    	Don't collect *HEAVY* CPE relate data
   -log-dir string
-        /path/to/log (default "/var/log/vuls")
+    	/path/to/log (default "/var/log/vuls")
   -log-json
-        output log as JSON
+    	output log as JSON
+  -log-to-file
+    	output log to file
+  -quiet
+    	quiet mode (no output)
   -years
-        Refresh JVN data of specific years.
-
+    	Refresh JVN data of specific years.
 ```
 
 - Fetch data for entire period

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -51,7 +51,7 @@ func (*FetchJvnCmd) Usage() string {
 		[-log-json]
 		[-light]
 		[-force]
-
+		[-expire]
 `
 }
 
@@ -91,6 +91,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
+	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys")
 }
 
 // Execute execute

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -91,7 +91,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
-	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys")
+	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 }
 
 // Execute execute

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -52,6 +52,7 @@ func (*FetchNvdCmd) Usage() string {
 		[-log-json]
 		[-light]
 		[-force]
+		[-expire]
 
 For the first time, run the blow command to fetch data for entire period. (It takes about 10 minutes)
    $ for i in ` + "`seq 2002 $(date +\"%Y\")`;" + ` do go-cve-dictionary fetchnvd -years $i; done
@@ -95,6 +96,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
+	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys")
 }
 
 // Execute execute

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -96,7 +96,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
-	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys")
+	f.UintVar(&c.Conf.Expire, "expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 }
 
 // Execute execute

--- a/config/config.go
+++ b/config/config.go
@@ -23,10 +23,7 @@ type Config struct {
 	DBPath   string
 	DBType   string
 
-	FetchJvnWeek       bool
-	FetchJvnMonth      bool
-	FetchJvnEntire     bool
-	FetchJvnPeriodChar string
+	Expire uint
 
 	Bind string `valid:"ipv4"`
 	Port string `valid:"port"`

--- a/db/redis.go
+++ b/db/redis.go
@@ -481,7 +481,7 @@ func (r *RedisDriver) UpsertFeedHash(m models.FeedMeta) error {
 		return fmt.Errorf("Failed to HSet META. err: %s", result.Err())
 	}
 	if config.Conf.Expire > 0 {
-		if err := pipe.Expire(ctx, hashKeyPrefix+"Meta", time.Duration(config.Conf.Expire*uint(time.Second))); err != nil {
+		if err := pipe.Expire(ctx, hashKeyPrefix+"Meta", time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 			return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 		}
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -480,6 +480,11 @@ func (r *RedisDriver) UpsertFeedHash(m models.FeedMeta) error {
 	if result := pipe.HSet(ctx, hashKeyPrefix+"Meta", m.URL, jn); result.Err() != nil {
 		return fmt.Errorf("Failed to HSet META. err: %s", result.Err())
 	}
+	if config.Conf.Expire > 0 {
+		if err := pipe.Expire(ctx, hashKeyPrefix+"Meta", time.Duration(config.Conf.Expire*uint(time.Second))); err != nil {
+			return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+		}
+	}
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("Failed to exec pipeline. err: %s", err)
 	}

--- a/db/redis.go
+++ b/db/redis.go
@@ -304,13 +304,11 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 	bar.Start()
 
 	for chunked := range chunkSlice(cves, 10) {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		for _, c := range chunked {
 			bar.Increment()
 
-			cpes := make([]models.Cpe, len(c.Jvn.Cpes))
-			copy(cpes, c.Jvn.Cpes)
+			cpes := append([]models.Cpe{}, c.Jvn.Cpes...)
 			c.Jvn.Cpes = nil
 
 			var jj []byte
@@ -318,26 +316,36 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
 			refreshedJvns = append(refreshedJvns, c.CveID)
-			if result := pipe.HSet(ctx, hashKeyPrefix+c.CveID, "Jvn", string(jj)); result.Err() != nil {
+			key := hashKeyPrefix + c.CveID
+			if result := pipe.HSet(ctx, key, "Jvn", string(jj)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 			if config.Conf.Expire > 0 {
-				if err := pipe.Expire(ctx, hashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 
 			for _, cpe := range cpes {
+				key := fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product)
 				if result := pipe.ZAdd(
 					ctx,
-					fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product),
+					key,
 					&redis.Z{Score: 0, Member: c.CveID},
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
 				if config.Conf.Expire > 0 {
-					if err := pipe.Expire(ctx, fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product), time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 						return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+					}
+				} else {
+					if err := pipe.Persist(ctx, key).Err(); err != nil {
+						return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 					}
 				}
 
@@ -346,12 +354,18 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 			if jc, err = json.Marshal(cpes); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
-			if result := pipe.HSet(ctx, cpeHashKeyPrefix+c.CveID, "Jvn", string(jc)); result.Err() != nil {
+
+			key = cpeHashKeyPrefix + c.CveID
+			if result := pipe.HSet(ctx, key, "Jvn", string(jc)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CPE. err: %s", result.Err())
 			}
 			if config.Conf.Expire > 0 {
-				if err := pipe.Expire(ctx, cpeHashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}
@@ -390,39 +404,47 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 	bar.Start()
 
 	for chunked := range chunkSlice(cves, 10) {
-		var pipe redis.Pipeliner
-		pipe = r.conn.Pipeline()
+		pipe := r.conn.Pipeline()
 		for _, c := range chunked {
 			bar.Increment()
 
-			cpes := make([]models.Cpe, len(c.NvdJSON.Cpes))
-			copy(cpes, c.NvdJSON.Cpes)
+			cpes := append([]models.Cpe{}, c.NvdJSON.Cpes...)
 			c.NvdJSON.Cpes = nil
 			var jn []byte
 			if jn, err = json.Marshal(c.NvdJSON); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
 			refreshedNvds = append(refreshedNvds, c.CveID)
-			if result := pipe.HSet(ctx, hashKeyPrefix+c.CveID, "NvdJSON", string(jn)); result.Err() != nil {
+			key := hashKeyPrefix + c.CveID
+			if result := pipe.HSet(ctx, key, "NvdJSON", string(jn)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
 			if config.Conf.Expire > 0 {
-				if err := pipe.Expire(ctx, hashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 
 			for _, cpe := range cpes {
+				key := fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product)
 				if result := pipe.ZAdd(
 					ctx,
-					fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product),
+					key,
 					&redis.Z{Score: 0, Member: c.CveID},
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
 				if config.Conf.Expire > 0 {
-					if err := pipe.Expire(ctx, fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product), time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 						return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+					}
+				} else {
+					if err := pipe.Persist(ctx, key).Err(); err != nil {
+						return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 					}
 				}
 			}
@@ -430,12 +452,18 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 			if jc, err = json.Marshal(cpes); err != nil {
 				return fmt.Errorf("Failed to marshal json. err: %s", err)
 			}
-			if result := pipe.HSet(ctx, cpeHashKeyPrefix+c.CveID, "NvdJSON", string(jc)); result.Err() != nil {
+
+			key = cpeHashKeyPrefix + c.CveID
+			if result := pipe.HSet(ctx, key, "NvdJSON", string(jc)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet NVD CPE. err: %s", result.Err())
 			}
 			if config.Conf.Expire > 0 {
-				if err := pipe.Expire(ctx, cpeHashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+				if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			} else {
+				if err := pipe.Persist(ctx, key).Err(); err != nil {
+					return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 				}
 			}
 		}
@@ -475,14 +503,18 @@ func (r *RedisDriver) UpsertFeedHash(m models.FeedMeta) error {
 		return fmt.Errorf("Failed to marshal json. err: %s", err)
 	}
 
-	var pipe redis.Pipeliner
-	pipe = r.conn.Pipeline()
-	if result := pipe.HSet(ctx, hashKeyPrefix+"Meta", m.URL, jn); result.Err() != nil {
+	pipe := r.conn.Pipeline()
+	key := hashKeyPrefix + "Meta"
+	if result := pipe.HSet(ctx, key, m.URL, jn); result.Err() != nil {
 		return fmt.Errorf("Failed to HSet META. err: %s", result.Err())
 	}
 	if config.Conf.Expire > 0 {
-		if err := pipe.Expire(ctx, hashKeyPrefix+"Meta", time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+		if err := pipe.Expire(ctx, key, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
 			return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+		}
+	} else {
+		if err := pipe.Persist(ctx, key).Err(); err != nil {
+			return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 		}
 	}
 	if _, err := pipe.Exec(ctx); err != nil {

--- a/db/redis.go
+++ b/db/redis.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/cheggaaa/pb/v3"
 	"github.com/go-redis/redis/v8"
 	"github.com/knqyf263/go-cpe/common"
 	"github.com/knqyf263/go-cpe/naming"
-	c "github.com/kotakanbe/go-cve-dictionary/config"
+	"github.com/kotakanbe/go-cve-dictionary/config"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"golang.org/x/xerrors"
@@ -295,7 +296,7 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 	var err error
 	var refreshedJvns []string
 	bar := pb.New(len(cves))
-	if c.Conf.Quiet {
+	if config.Conf.Quiet {
 		bar.SetWriter(ioutil.Discard)
 	} else {
 		bar.SetWriter(os.Stderr)
@@ -320,6 +321,11 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 			if result := pipe.HSet(ctx, hashKeyPrefix+c.CveID, "Jvn", string(jj)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
+			if config.Conf.Expire > 0 {
+				if err := pipe.Expire(ctx, hashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			}
 
 			for _, cpe := range cpes {
 				if result := pipe.ZAdd(
@@ -329,6 +335,12 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
+				if config.Conf.Expire > 0 {
+					if err := pipe.Expire(ctx, fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product), time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+						return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+					}
+				}
+
 			}
 			var jc []byte
 			if jc, err = json.Marshal(cpes); err != nil {
@@ -336,6 +348,11 @@ func (r *RedisDriver) InsertJvn(cves []models.CveDetail) error {
 			}
 			if result := pipe.HSet(ctx, cpeHashKeyPrefix+c.CveID, "Jvn", string(jc)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CPE. err: %s", result.Err())
+			}
+			if config.Conf.Expire > 0 {
+				if err := pipe.Expire(ctx, cpeHashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
 			}
 		}
 		if _, err = pipe.Exec(ctx); err != nil {
@@ -365,7 +382,7 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 	var err error
 	var refreshedNvds []string
 	bar := pb.New(len(cves))
-	if c.Conf.Quiet {
+	if config.Conf.Quiet {
 		bar.SetWriter(ioutil.Discard)
 	} else {
 		bar.SetWriter(os.Stderr)
@@ -389,6 +406,11 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 			if result := pipe.HSet(ctx, hashKeyPrefix+c.CveID, "NvdJSON", string(jn)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 			}
+			if config.Conf.Expire > 0 {
+				if err := pipe.Expire(ctx, hashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
+			}
 
 			for _, cpe := range cpes {
 				if result := pipe.ZAdd(
@@ -398,6 +420,11 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 				); result.Err() != nil {
 					return fmt.Errorf("Failed to ZAdd cpe. err: %s", result.Err())
 				}
+				if config.Conf.Expire > 0 {
+					if err := pipe.Expire(ctx, fmt.Sprintf("%s%s::%s", hashKeyPrefix, cpe.Vendor, cpe.Product), time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+						return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+					}
+				}
 			}
 			var jc []byte
 			if jc, err = json.Marshal(cpes); err != nil {
@@ -405,6 +432,11 @@ func (r *RedisDriver) InsertNvdJSON(cves []models.CveDetail) error {
 			}
 			if result := pipe.HSet(ctx, cpeHashKeyPrefix+c.CveID, "NvdJSON", string(jc)); result.Err() != nil {
 				return fmt.Errorf("Failed to HSet NVD CPE. err: %s", result.Err())
+			}
+			if config.Conf.Expire > 0 {
+				if err := pipe.Expire(ctx, cpeHashKeyPrefix+c.CveID, time.Duration(config.Conf.Expire*uint(time.Second))).Err(); err != nil {
+					return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+				}
 			}
 		}
 		if _, err = pipe.Exec(ctx); err != nil {


### PR DESCRIPTION
# What did you implement:
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
127.0.0.1:6379> TTL CVE#CVE-2021-37600
(integer) 70
127.0.0.1:6379> TTL CVE#C#CVE-2021-31999
(integer) 65
127.0.0.1:6379> TTL CVE#microsoft::windows_10
(integer) 70
127.0.0.1:6379> TTL CVE#Meta
(integer) 16

127.0.0.1:6379> keys CVE#*
(empty array)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
- https://redis.io/commands/expire
