### PR TITLE
feat(fetch): fill in CpeBase by default and change the option name

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -89,7 +89,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 		"http://proxy-url:port (default: empty)",
 	)
 
-	f.BoolVar(&c.Conf.Light, "light", true, "Don't collect *HEAVY* CPE relate data")
+	f.BoolVar(&c.Conf.Full, "full", false, "Collect large amounts of CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
 }
 

--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -89,7 +89,7 @@ func (p *FetchJvnCmd) SetFlags(f *flag.FlagSet) {
 		"http://proxy-url:port (default: empty)",
 	)
 
-	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
+	f.BoolVar(&c.Conf.Light, "light", true, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
 }
 

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -93,7 +93,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"http://proxy-url:port (default: empty)",
 	)
 
-	f.BoolVar(&c.Conf.Light, "light", false, "Don't collect *HEAVY* CPE relate data")
+	f.BoolVar(&c.Conf.Light, "light", true, "Don't collect *HEAVY* CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
 }
 

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -93,7 +93,7 @@ func (p *FetchNvdCmd) SetFlags(f *flag.FlagSet) {
 		"http://proxy-url:port (default: empty)",
 	)
 
-	f.BoolVar(&c.Conf.Light, "light", true, "Don't collect *HEAVY* CPE relate data")
+	f.BoolVar(&c.Conf.Full, "full", false, "Collect large amounts of CPE relate data")
 	f.BoolVar(&c.Conf.Force, "force", false, "Force update")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Debug    bool
 	DebugSQL bool
 	Quiet    bool
-	Light    bool
+	Full     bool
 	Force    bool
 
 	DumpPath string

--- a/fetcher/jvn/xml/jvn.go
+++ b/fetcher/jvn/xml/jvn.go
@@ -304,21 +304,19 @@ func convertToModel(item *Item) (cves []models.CveDetail, err error) {
 			fmt.Errorf("Failed to collect links. err: %s", err)
 	}
 
+	// Cpes
 	cpes := []models.Cpe{}
-	if !c.Conf.Light {
-		// Cpes
-		for _, c := range item.Cpes {
-			cpeBase, err := fetcher.ParseCpeURI(c.Value)
-			if err != nil {
-				// logging only
-				log.Infof("Failed to parse CPE URI: %s, %s", c.Value, err)
-				continue
-			}
-			cpes = append(cpes, models.Cpe{
-				CpeBase: *cpeBase,
-				EnvCpes: []models.EnvCpe{},
-			})
+	for _, c := range item.Cpes {
+		cpeBase, err := fetcher.ParseCpeURI(c.Value)
+		if err != nil {
+			// logging only
+			log.Infof("Failed to parse CPE URI: %s, %s", c.Value, err)
+			continue
 		}
+		cpes = append(cpes, models.Cpe{
+			CpeBase: *cpeBase,
+			EnvCpes: []models.EnvCpe{},
+		})
 	}
 
 	publish, err := parseJvnTime(item.Issued)

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -295,7 +295,7 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 
 	affects := []models.Affect{}
 	// Affects
-	if !c.Conf.Light {
+	if c.Conf.Full {
 		for _, vendor := range item.Cve.Affects.Vendor.VendorData {
 			for _, prod := range vendor.Product.ProductData {
 				for _, version := range prod.Version.VersionData {
@@ -367,7 +367,7 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 						)
 					}
 				} else {
-					if !c.Conf.Light && node.Operator == "AND" {
+					if c.Conf.Full && node.Operator == "AND" {
 						for i, c := range nodeCpes {
 							cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
 							if err != nil {

--- a/fetcher/nvd/json/nvd.go
+++ b/fetcher/nvd/json/nvd.go
@@ -294,9 +294,8 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 	}
 
 	affects := []models.Affect{}
-	cpes := []models.Cpe{}
+	// Affects
 	if !c.Conf.Light {
-		// Affects
 		for _, vendor := range item.Cve.Affects.Vendor.VendorData {
 			for _, prod := range vendor.Product.ProductData {
 				for _, version := range prod.Version.VersionData {
@@ -308,94 +307,95 @@ func convertToModel(item *CveItem) (*models.CveDetail, error) {
 				}
 			}
 		}
+	}
 
-		for _, node := range item.Configurations.Nodes {
-			if node.Negate {
+	cpes := []models.Cpe{}
+	for _, node := range item.Configurations.Nodes {
+		if node.Negate {
+			continue
+		}
+
+		nodeCpes := []models.Cpe{}
+		for _, cpe := range node.Cpes {
+			// if !cpe.Vulnerable {
+			// CVE-2017-14492 and CVE-2017-8581 has a cpe that has vulnerable:false.
+			// But these vulnerable: false cpe is also vulnerable...
+			// So, ignore the vulnerable flag of this layer(under nodes>cpe)
+			// }
+			cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+			if err != nil {
+				// logging only
+				log.Infof("Failed to parse CpeURI %s: %s", cpe.Cpe23URI, err)
 				continue
 			}
-
-			nodeCpes := []models.Cpe{}
-			for _, cpe := range node.Cpes {
-				// if !cpe.Vulnerable {
-				// CVE-2017-14492 and CVE-2017-8581 has a cpe that has vulnerable:false.
-				// But these vulnerable: false cpe is also vulnerable...
-				// So, ignore the vulnerable flag of this layer(under nodes>cpe)
-				// }
-				cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-				if err != nil {
-					// logging only
-					log.Infof("Failed to parse CpeURI %s: %s", cpe.Cpe23URI, err)
-					continue
-				}
-				cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-				cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-				cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-				cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-				nodeCpes = append(nodeCpes, models.Cpe{
-					CpeBase: *cpeBase,
-					EnvCpes: []models.EnvCpe{},
-				})
-				if !checkIfVersionParsable(cpeBase) {
-					return nil, fmt.Errorf(
-						"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
-						item.Cve.CveDataMeta.ID,
-						pp.Sprintf("%v", *item),
-					)
-				}
+			cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+			cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+			cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+			cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+			nodeCpes = append(nodeCpes, models.Cpe{
+				CpeBase: *cpeBase,
+				EnvCpes: []models.EnvCpe{},
+			})
+			if !checkIfVersionParsable(cpeBase) {
+				return nil, fmt.Errorf(
+					"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
+					item.Cve.CveDataMeta.ID,
+					pp.Sprintf("%v", *item),
+				)
 			}
-			for _, child := range node.Children {
-				for _, cpe := range child.Cpes {
-					if cpe.Vulnerable {
-						cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-						if err != nil {
-							return nil, err
-						}
-						cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-						cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-						cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-						cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-						nodeCpes = append(nodeCpes, models.Cpe{
-							CpeBase: *cpeBase,
-							EnvCpes: []models.EnvCpe{},
-						})
-						if !checkIfVersionParsable(cpeBase) {
-							return nil, fmt.Errorf(
-								"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
-								item.Cve.CveDataMeta.ID,
-								pp.Sprintf("%v", *item),
-							)
-						}
-					} else {
-						if node.Operator == "AND" {
-							for i, c := range nodeCpes {
-								cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
-								if err != nil {
-									return nil, err
-								}
-								cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
-								cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
-								cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
-								cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
-								nodeCpes[i].EnvCpes = append(c.EnvCpes, models.EnvCpe{
-									CpeBase: *cpeBase,
-								})
+		}
+		for _, child := range node.Children {
+			for _, cpe := range child.Cpes {
+				if cpe.Vulnerable {
+					cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+					if err != nil {
+						return nil, err
+					}
+					cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+					cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+					cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+					cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+					nodeCpes = append(nodeCpes, models.Cpe{
+						CpeBase: *cpeBase,
+						EnvCpes: []models.EnvCpe{},
+					})
+					if !checkIfVersionParsable(cpeBase) {
+						return nil, fmt.Errorf(
+							"Version parse err. Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: %s, Content:%s",
+							item.Cve.CveDataMeta.ID,
+							pp.Sprintf("%v", *item),
+						)
+					}
+				} else {
+					if !c.Conf.Light && node.Operator == "AND" {
+						for i, c := range nodeCpes {
+							cpeBase, err := fetcher.ParseCpeURI(cpe.Cpe23URI)
+							if err != nil {
+								return nil, err
+							}
+							cpeBase.VersionStartExcluding = cpe.VersionStartExcluding
+							cpeBase.VersionStartIncluding = cpe.VersionStartIncluding
+							cpeBase.VersionEndExcluding = cpe.VersionEndExcluding
+							cpeBase.VersionEndIncluding = cpe.VersionEndIncluding
+							nodeCpes[i].EnvCpes = append(c.EnvCpes, models.EnvCpe{
+								CpeBase: *cpeBase,
+							})
 
-								if !checkIfVersionParsable(cpeBase) {
-									return nil, fmt.Errorf(
-										"Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: Version parse err: %s, Content:%s",
-										item.Cve.CveDataMeta.ID,
-										pp.Sprintf("%v", *item),
-									)
-								}
+							if !checkIfVersionParsable(cpeBase) {
+								return nil, fmt.Errorf(
+									"Please add a issue on [GitHub](https://github.com/kotakanbe/go-cve-dictionary/issues/new). Title: Version parse err: %s, Content:%s",
+									item.Cve.CveDataMeta.ID,
+									pp.Sprintf("%v", *item),
+								)
 							}
 						}
 					}
 				}
 			}
-			cpes = append(cpes, nodeCpes...)
 		}
-
+		cpes = append(cpes, nodeCpes...)
 	}
+
 	// Description
 	descs := []models.Description{}
 	for _, desc := range item.Cve.Description.DescriptionData {


### PR DESCRIPTION
# What did you implement:

Fixes #201 

First, it fills in the data in CpeBase by default.
Also, rename `light` to `full`, and use `fetchnvd` to save more CPE data to the DB only when `full` is enabled.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
```console
$ go-cve-dictionary.master fetchnvd --last2y --dbpath=$(pwd)/cve.master.sqlite3
$ go-cve-dictionary.pr fetchnvd --last2y --dbpath=$(pwd)/cve.pr.sqlite3

$ ll cve.*.sqlite3 
-rw-r--r-- 1 mainek00n mainek00n 291M Aug 11 05:36 cve.master.sqlite3
-rw-r--r-- 1 mainek00n mainek00n 177M Aug 11 06:07 cve.pr.sqlite3

$ sqlite3 cve.master.sqlite3
sqlite> SELECT COUNT(id) FROM env_cpes;
232662

$ sqlite3 cve.pr.sqlite3
sqlite> SELECT COUNT(id) FROM env_cpes;
0

$ go-cve-dictionary.pr fetchnvd --last2y --full --dbpath=$(pwd)/cve.pr.sqlite3

$ ll cve.pr.sqlite3 
-rw-r--r-- 1 mainek00n mainek00n 291M Aug 11 06:14 cve.pr.sqlite3

$ sqlite3 cve.pr.sqlite3
sqlite> SELECT COUNT(id) FROM env_cpes;
232662
```
# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
