### PR TITLE
feat(db): filter contents of CveDetail by CPE URI

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -352,3 +352,41 @@ func matchExactByAffects(uri string, affects []models.NvdAffect) (bool, error) {
 func trimBSlash(s string) string {
 	return strings.Replace(s, `\`, "", -1)
 }
+
+func filterCVEDetailbyCPEURI(uri string, d *models.CveDetail) error {
+	if d == nil {
+		return nil
+	}
+
+	nvds := append([]models.Nvd{}, d.Nvd...)
+	d.Nvd = []models.Nvd{}
+	for _, nvd := range nvds {
+		for _, cpe := range nvd.Cpes {
+			matched, err := match(uri, cpe.CpeBase)
+			if err != nil {
+				return err
+			}
+			if matched {
+				d.Nvd = append(d.Nvd, nvd)
+				break
+			}
+		}
+	}
+
+	jvns := append([]models.Jvn{}, d.Jvn...)
+	d.Jvn = []models.Jvn{}
+	for _, jvn := range jvns {
+		for _, cpe := range jvn.Cpes {
+			matched, err := isSamePartVendorProduct(uri, cpe.URI)
+			if err != nil {
+				return err
+			}
+			if matched {
+				d.Jvn = append(d.Jvn, jvn)
+				break
+			}
+		}
+	}
+
+	return nil
+}

--- a/db/db.go
+++ b/db/db.go
@@ -277,7 +277,7 @@ func matchCpe(uri string, cve *models.CveDetail) (nvdMatch, jvnMatch bool, err e
 
 	for _, jvn := range cve.Jvn {
 		for _, jvnCpe := range jvn.Cpes {
-			// If NVD has data of the same `type`, `verndor`, and `product`, NVD is used in priority.
+			// If NVD has data of the same `part`, `vendor`, and `product`, NVD is used in priority.
 			// Because NVD has version information, but JVN does not.
 			found := false
 			for _, nvdCpe := range nvdCpes {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/kotakanbe/go-cve-dictionary/models"
@@ -534,5 +535,118 @@ func Test_matchCpe(t *testing.T) {
 				t.Errorf("matchCpe() jvn = %v, want %v", jvnGot, tt.jvnWant)
 			}
 		})
+	}
+}
+
+func Test_filterCVEDetailbyCPEURI(t *testing.T) {
+	type args struct {
+		uri string
+		cve *models.CveDetail
+	}
+	tests := []struct {
+		args     args
+		expected *models.CveDetail
+	}{
+		{
+			args: args{
+				uri: "cpe:/o:vendor:product:1.0.0",
+				cve: nil,
+			},
+			expected: nil,
+		},
+		{
+			args: args{
+				uri: "cpe:/o:vendor:product:1.0.0",
+				cve: &models.CveDetail{
+					Nvd: []models.Nvd{
+						{
+							Cpes: []models.NvdCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+							},
+						},
+						{
+							Cpes: []models.NvdCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+							},
+						},
+					},
+					Jvn: []models.Jvn{
+						{
+							Cpes: []models.JvnCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
+							},
+						},
+					},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvd: []models.Nvd{
+					{
+						Cpes: []models.NvdCpe{
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+						},
+					},
+				},
+				Jvn: []models.Jvn{
+					{
+						Cpes: []models.JvnCpe{
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			args: args{
+				uri: "cpe:/o:vendor:product",
+				cve: &models.CveDetail{
+					Nvd: []models.Nvd{
+						{
+							Cpes: []models.NvdCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+							},
+						},
+					},
+					Jvn: []models.Jvn{
+						{
+							Cpes: []models.JvnCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
+							},
+						},
+						{
+							Cpes: []models.JvnCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product2"}},
+							},
+						},
+					},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvd: []models.Nvd{
+					{
+						Cpes: []models.NvdCpe{
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+						},
+					},
+				},
+				Jvn: []models.Jvn{
+					{
+						Cpes: []models.JvnCpe{
+							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tt := range tests {
+		_ = filterCVEDetailbyCPEURI(tt.args.uri, tt.args.cve)
+		if !reflect.DeepEqual(tt.args.cve, tt.expected) {
+			t.Errorf("[%d] expected: %+v, actual: %+v", i, tt.expected, tt.args.cve)
+		}
 	}
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -347,14 +347,7 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err != nil {
 			return nil, err
 		}
-		nvdMatch, jvnMatch, err := matchCpe(uri, d)
-		if err != nil {
-			log.Warnf("Failed to compare the version:%s %s %#v",
-				err, uri, d)
-			continue
-		}
-
-		if nvdMatch || jvnMatch {
+		if len(d.Nvd) > 0 || len(d.Jvn) > 0 {
 			details = append(details, *d)
 		}
 	}

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -305,8 +305,7 @@ func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs
 		if err != nil {
 			return nil, nil, err
 		}
-		err = filterCVEDetailbyCPEURI(uri, d)
-		if err != nil {
+		if err := filterCVEDetailbyCPEURI(uri, d); err != nil {
 			return nil, nil, err
 		}
 		nvdMatch, jvnMatch, err := matchCpe(uri, d)
@@ -343,8 +342,7 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = filterCVEDetailbyCPEURI(uri, d)
-		if err != nil {
+		if err := filterCVEDetailbyCPEURI(uri, d); err != nil {
 			return nil, err
 		}
 		if len(d.Nvd) > 0 || len(d.Jvn) > 0 {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -323,39 +323,34 @@ func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs
 
 // GetByCpeURI Select Cve information from DB.
 func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
-	nvdCveIDs, jvnCveIDs, err := r.GetCveIDsByCpeURI(uri)
+	cveIDs, err := r.getCveIDsByPartVendorProduct(uri)
 	if err != nil {
 		return nil, err
 	}
 
-	cveMap := map[string]models.CveDetail{}
-	for _, cveID := range nvdCveIDs {
-		cveMap[cveID] = models.CveDetail{CveID: cveID, CveIDSource: models.NvdType}
+	uniqCveIDs := map[string]bool{}
+	for _, v := range cveIDs {
+		uniqCveIDs[v] = true
 	}
 
-	for _, cveID := range jvnCveIDs {
-		_, ok := cveMap[cveID]
-		if !ok {
-			cveMap[cveID] = models.CveDetail{CveID: cveID, CveIDSource: models.JvnType}
-		}
-	}
-
-	cves := []models.CveDetail{}
-	for _, c := range cveMap {
-		detail, err := r.Get(c.CveID)
+	details := []models.CveDetail{}
+	for cveID := range uniqCveIDs {
+		d, err := r.Get(cveID)
 		if err != nil {
 			return nil, err
 		}
+		nvdMatch, jvnMatch, err := matchCpe(uri, d)
+		if err != nil {
+			log.Warnf("Failed to compare the version:%s %s %#v",
+				err, uri, d)
+			continue
+		}
 
-		cves = append(cves, models.CveDetail{
-			CveID:       c.CveID,
-			CveIDSource: c.CveIDSource,
-			Nvd:         detail.Nvd,
-			Jvn:         detail.Jvn,
-		})
+		if nvdMatch || jvnMatch {
+			details = append(details, *d)
+		}
 	}
-
-	return cves, nil
+	return details, nil
 }
 
 // InsertJvn inserts Cve Information into DB

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -305,6 +305,10 @@ func (r *RDBDriver) GetCveIDsByCpeURI(uri string) (nvdCveIDs []string, jvnCveIDs
 		if err != nil {
 			return nil, nil, err
 		}
+		err = filterCVEDetailbyCPEURI(uri, d)
+		if err != nil {
+			return nil, nil, err
+		}
 		nvdMatch, jvnMatch, err := matchCpe(uri, d)
 		if err != nil {
 			log.Warnf("Failed to compare the version:%s %s %#v",
@@ -336,6 +340,10 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	details := []models.CveDetail{}
 	for cveID := range uniqCveIDs {
 		d, err := r.Get(cveID)
+		if err != nil {
+			return nil, err
+		}
+		err = filterCVEDetailbyCPEURI(uri, d)
 		if err != nil {
 			return nil, err
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -235,8 +235,7 @@ func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, error) 
 		if err != nil {
 			return nil, nil, err
 		}
-		err = filterCVEDetailbyCPEURI(uri, d)
-		if err != nil {
+		if err := filterCVEDetailbyCPEURI(uri, d); err != nil {
 			return nil, nil, err
 		}
 		nvdMatch, jvnMatch, err := matchCpe(uri, d)
@@ -281,8 +280,7 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = filterCVEDetailbyCPEURI(uri, d)
-		if err != nil {
+		if err := filterCVEDetailbyCPEURI(uri, d); err != nil {
 			return nil, err
 		}
 		if len(d.Nvd) > 0 || len(d.Jvn) > 0 {

--- a/db/redis.go
+++ b/db/redis.go
@@ -235,6 +235,10 @@ func (r *RedisDriver) GetCveIDsByCpeURI(uri string) ([]string, []string, error) 
 		if err != nil {
 			return nil, nil, err
 		}
+		err = filterCVEDetailbyCPEURI(uri, d)
+		if err != nil {
+			return nil, nil, err
+		}
 		nvdMatch, jvnMatch, err := matchCpe(uri, d)
 		if err != nil {
 			log.Warnf("Failed to compare the version:%s %s %#v",
@@ -274,6 +278,10 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	details := []models.CveDetail{}
 	for cveID := range uniqCveIDs {
 		d, err := r.Get(cveID)
+		if err != nil {
+			return nil, err
+		}
+		err = filterCVEDetailbyCPEURI(uri, d)
 		if err != nil {
 			return nil, err
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -284,11 +284,6 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 			// continue matching
 			continue
 		}
-		if nvdMatch {
-			d.CveIDSource = models.NvdType
-		} else if jvnMatch {
-			d.CveIDSource = models.JvnType
-		}
 
 		if nvdMatch || jvnMatch {
 			details = append(details, *d)

--- a/db/redis.go
+++ b/db/redis.go
@@ -285,15 +285,7 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 		if err != nil {
 			return nil, err
 		}
-		nvdMatch, jvnMatch, err := matchCpe(uri, d)
-		if err != nil {
-			log.Warnf("Failed to compare the version:%s %s %#v",
-				err, uri, d)
-			// continue matching
-			continue
-		}
-
-		if nvdMatch || jvnMatch {
+		if len(d.Nvd) > 0 || len(d.Jvn) > 0 {
 			details = append(details, *d)
 		}
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -157,10 +157,9 @@ func (f FetchMeta) OutDated() bool {
 
 // CveDetail :
 type CveDetail struct {
-	CveID       string
-	CveIDSource string // specify whether CVE-ID was obtained from NvdCpe or JvnCpe when retrieving CVE-ID from CpeURI(Fn: GetByCpeURI)
-	Nvd         []Nvd
-	Jvn         []Jvn
+	CveID string
+	Nvd   []Nvd
+	Jvn   []Jvn
 }
 
 // HasNvd returns true if NVD contents


### PR DESCRIPTION
# What did you implement:
When searching by CPE URI, items that do not have a CPE that matches the CPE URI used in the search will not be responded to.
Also, delete `CveDetail.CveIDSource` as it is not needed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
// upstream/master
$ curl -H "Content-type: application/json" -X POST -d '{"name": "cpe:/o:titan:sf_rush_smart_band_firmware:1.12"}' http://127.0.0.1:1323/cpes | jq
[
  {
    "CveID": "CVE-2020-11539",
    "CveIDSource": "NVD",
    "Nvd": [
      {
        "CveID": "CVE-2020-11539",
        "Cpes": [
          {
            "URI": "cpe:/o:titan:sf_rush_smart_band_firmware:1.12",
          }
        ],
      }
    ],
    "Jvn": [
      {
        "CveID": "CVE-2020-11539",
        "Cpes": [
          {
            "URI": "cpe:/o:d-link:dir-615_firmware",
        ],
      },
      {
        "CveID": "CVE-2020-11539",
        "Cpes": [
          {
            "URI": "cpe:/o:titan:sf_rush_smart_band_firmware",
          }
        ],
      }
    ]
  }
]

// PR
$ curl -H "Content-type: application/json" -X POST -d '{"name": "cpe:/o:titan:sf_rush_smart_band_firmware:1.12"}' http://127.0.0.1:1323/cpes | jq
[
  {
    "CveID": "CVE-2020-11539",
    "Nvd": [
      {
        "CveID": "CVE-2020-11539",
        "Cpes": [
          {
            "URI": "cpe:/o:titan:sf_rush_smart_band_firmware:1.12",
          }
        ],
      }
    ],
    "Jvn": [
      {
        "CveID": "CVE-2020-11539",
        "Cpes": [
          {
            "URI": "cpe:/o:titan:sf_rush_smart_band_firmware",
          }
        ],
      }
    ]
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
