### PR TITLE
feat(cpematch): rpm match if version range defined in NVD is not semver style

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	version "github.com/hashicorp/go-version"
+	rpmver "github.com/knqyf263/go-rpm-version"
 	log "github.com/kotakanbe/go-cve-dictionary/log"
 	"github.com/kotakanbe/go-cve-dictionary/models"
 	"github.com/spf13/viper"
@@ -128,21 +129,41 @@ func parseCpeURI(cpe22uri string) (*models.CpeBase, error) {
 	}, nil
 }
 
-func makeVersionConstraint(dict models.CpeBase) string {
+func makeVersionConstraint(dict models.CpeBase) (string, error) {
 	constraints := []string{}
 	if dict.VersionStartIncluding != "" {
+		_, err := version.NewSemver(dict.VersionStartIncluding)
+		if err != nil {
+			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionStartIncluding, err)
+			return "", err
+		}
 		constraints = append(constraints, ">= "+dict.VersionStartIncluding)
 	}
 	if dict.VersionStartExcluding != "" {
+		_, err := version.NewSemver(dict.VersionStartExcluding)
+		if err != nil {
+			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionStartExcluding, err)
+			return "", err
+		}
 		constraints = append(constraints, "> "+dict.VersionStartExcluding)
 	}
 	if dict.VersionEndIncluding != "" {
+		_, err := version.NewSemver(dict.VersionEndIncluding)
+		if err != nil {
+			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionEndIncluding, err)
+			return "", err
+		}
 		constraints = append(constraints, "<= "+dict.VersionEndIncluding)
 	}
 	if dict.VersionEndExcluding != "" {
+		_, err := version.NewSemver(dict.VersionEndExcluding)
+		if err != nil {
+			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionEndExcluding, err)
+			return "", err
+		}
 		constraints = append(constraints, "< "+dict.VersionEndExcluding)
 	}
-	return strings.Join(constraints, ", ")
+	return strings.Join(constraints, ", "), nil
 }
 
 func isSamePartVendorProduct(cpeA, cpeB string) (bool, error) {
@@ -156,9 +177,9 @@ func isSamePartVendorProduct(cpeA, cpeB string) (bool, error) {
 		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeB, err)
 	}
 
-	if a.Get("part") == b.Get("part") &&
-		a.Get("vendor") == b.Get("vendor") &&
-		a.Get("product") == b.Get("product") {
+	if a.Get(common.AttributePart) == b.Get(common.AttributePart) &&
+		a.Get(common.AttributeVendor) == b.Get(common.AttributeVendor) &&
+		a.Get(common.AttributeProduct) == b.Get(common.AttributeProduct) {
 		return true, nil
 	}
 	return false, nil
@@ -175,9 +196,9 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeInNvd.URI, err)
 	}
 
-	if cpeInNvdWfn.Get("part") != specified.Get("part") ||
-		cpeInNvdWfn.Get("vendor") != specified.Get("vendor") ||
-		cpeInNvdWfn.Get("product") != specified.Get("product") {
+	if cpeInNvdWfn.Get(common.AttributePart) != specified.Get(common.AttributePart) ||
+		cpeInNvdWfn.Get(common.AttributeVendor) != specified.Get(common.AttributeVendor) ||
+		cpeInNvdWfn.Get(common.AttributeProduct) != specified.Get(common.AttributeProduct) {
 		return false, nil
 	}
 
@@ -185,8 +206,8 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 		log.Debugf("%s equals %s", specified.String(), cpeInNvd.URI)
 		return true, nil
 	}
-	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
 
+	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
 	switch specifiedVer {
 	case "NA", "ANY":
 		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
@@ -194,29 +215,14 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 		}
 		return isSuperORSubset(cpeInNvdWfn, specified), nil
 	default:
-		constraintStr := makeVersionConstraint(cpeInNvd)
-		if constraintStr != "" {
-			constraints, err := version.NewConstraint(constraintStr)
-			if err != nil {
-				return false, err
+		ok, err := matchSemver(specifiedVer, cpeInNvd)
+		if err != nil {
+			// version range specified in cpeInNvd are not defined as semver style
+			if ok := matchRpmVer(specifiedVer, cpeInNvd); ok {
+				return isSuperORSubset(cpeInNvdWfn, specified), nil
 			}
-			specifiedVer = strings.Replace(specifiedVer, `\`, "", -1)
-			v, err := version.NewVersion(specifiedVer)
-			if err != nil {
-				log.Debugf("Failed to parse the semver: %s, err: %s", specifiedVer, err)
-				return false, err
-			}
-			if !constraints.Check(v) {
-				return false, nil
-			}
-			log.Debugf("%s satisfies version constraints %s", v, constraintStr)
-
-			if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
-				return false, err
-			}
-			if err := specified.Set(common.AttributeVersion, nil); err != nil {
-				return false, err
-			}
+		}
+		if ok {
 			return isSuperORSubset(cpeInNvdWfn, specified), nil
 		}
 
@@ -243,21 +249,71 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 	}
 }
 
+func matchSemver(specifiedVer string, cpeInNvd models.CpeBase) (ok bool, err error) {
+	constraintStr, err := makeVersionConstraint(cpeInNvd)
+	if err != nil {
+		return false, err
+	}
+	if constraintStr == "" {
+		return false, nil
+	}
+
+	constraints, err := version.NewConstraint(constraintStr)
+	if err != nil {
+		return false, err
+	}
+	specifiedVer = strings.Replace(specifiedVer, `\`, "", -1)
+	v, err := version.NewSemver(specifiedVer)
+	if err != nil {
+		log.Debugf("Failed to parse the semver: %s, err: %s", specifiedVer, err)
+		return false, err
+	}
+	if ok = constraints.Check(v); ok {
+		log.Debugf("%s satisfies version constraints %s", specifiedVer, constraintStr)
+	}
+	return
+}
+
+func matchRpmVer(specifiedVer string, cpeInNvd models.CpeBase) bool {
+	specified := rpmver.NewVersion(specifiedVer)
+
+	// verStart <= specified
+	if cpeInNvd.VersionStartIncluding != "" {
+		ver := rpmver.NewVersion(cpeInNvd.VersionStartIncluding)
+		if !specified.Equal(ver) && specified.LessThan(ver) {
+			return false
+		}
+	}
+	// verStart < specified
+	if cpeInNvd.VersionStartExcluding != "" {
+		ver := rpmver.NewVersion(cpeInNvd.VersionStartExcluding)
+		if specified.Equal(ver) || specified.LessThan(ver) {
+			return false
+		}
+	}
+	// specified <= verEnd
+	if cpeInNvd.VersionEndIncluding != "" {
+		ver := rpmver.NewVersion(cpeInNvd.VersionEndIncluding)
+		if !specified.Equal(ver) && ver.LessThan(specified) {
+			return false
+		}
+	}
+	// specified < verEnd
+	if cpeInNvd.VersionEndExcluding != "" {
+		ver := rpmver.NewVersion(cpeInNvd.VersionEndExcluding)
+		if specified.Equal(ver) || ver.LessThan(specified) {
+			return false
+		}
+	}
+	return true
+}
+
 func matchCpe(uri string, cve *models.CveDetail) (nvdMatch, jvnMatch bool, err error) {
 	for _, nvd := range cve.Nvds {
 		for _, cpe := range nvd.Cpes {
 			match, err := match(uri, cpe.CpeBase)
 			if err != nil {
 				log.Debugf("Failed to match: %s", err)
-
-				// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
-				ok, err := matchExactByAffects(uri, nvd.Affects)
-				if err != nil {
-					return false, false, err
-				}
-				if ok {
-					return true, false, nil
-				}
 				continue
 			} else if match {
 				return true, false, nil
@@ -320,36 +376,6 @@ func isSuperORSubset(source, target common.WellFormedName) bool {
 	return false
 }
 
-func matchExactByAffects(uri string, affects []models.NvdAffect) (bool, error) {
-	wfn, err := naming.UnbindURI(uri)
-	if err != nil {
-		return false, err
-	}
-	var vendor, product, ver string
-	var ok bool
-	if vendor, ok = wfn.Get("vendor").(string); !ok {
-		log.Errorf("Failed to assert vendor. cpe uri: %s", uri)
-		return false, nil
-	}
-	if product, ok = wfn.Get("product").(string); !ok {
-		log.Errorf("Failed to assert product. cpe uri: %s", uri)
-		return false, nil
-	}
-	if ver, ok = wfn.Get("version").(string); !ok {
-		log.Errorf("Failed to assert version. cpe uri: %s", uri)
-		return false, nil
-	}
-
-	for _, a := range affects {
-		if trimBSlash(a.Vendor) == trimBSlash(vendor) &&
-			trimBSlash(a.Product) == trimBSlash(product) &&
-			trimBSlash(a.Version) == trimBSlash(ver) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func trimBSlash(s string) string {
 	return strings.Replace(s, `\`, "", -1)
 }
@@ -366,15 +392,6 @@ func filterCveDetailByCpeURI(uri string, d *models.CveDetail) error {
 			matched, err := match(uri, cpe.CpeBase)
 			if err != nil {
 				log.Debugf("Failed to match. err: %s, uri: %s, CpeBase: %#v", err, uri, cpe.CpeBase)
-
-				// Try to exact match by vendor, product and version if the version in CPE is not a semVer style.
-				ok, err := matchExactByAffects(uri, nvd.Affects)
-				if err != nil {
-					return err
-				}
-				if ok {
-					matched = true
-				}
 			}
 			if matched {
 				d.Nvds = append(d.Nvds, nvd)

--- a/db/db.go
+++ b/db/db.go
@@ -129,39 +129,39 @@ func parseCpeURI(cpe22uri string) (*models.CpeBase, error) {
 	}, nil
 }
 
-func makeVersionConstraint(dict models.CpeBase) (string, error) {
+func makeVersionConstraint(cpeInNvd models.CpeBase) (string, error) {
 	constraints := []string{}
-	if dict.VersionStartIncluding != "" {
-		_, err := version.NewSemver(dict.VersionStartIncluding)
+	if cpeInNvd.VersionStartIncluding != "" {
+		_, err := version.NewSemver(cpeInNvd.VersionStartIncluding)
 		if err != nil {
-			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionStartIncluding, err)
+			log.Debugf("Failed to parse the semver: %s, err: %s", cpeInNvd.VersionStartIncluding, err)
 			return "", err
 		}
-		constraints = append(constraints, ">= "+dict.VersionStartIncluding)
+		constraints = append(constraints, ">= "+cpeInNvd.VersionStartIncluding)
 	}
-	if dict.VersionStartExcluding != "" {
-		_, err := version.NewSemver(dict.VersionStartExcluding)
+	if cpeInNvd.VersionStartExcluding != "" {
+		_, err := version.NewSemver(cpeInNvd.VersionStartExcluding)
 		if err != nil {
-			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionStartExcluding, err)
+			log.Debugf("Failed to parse the semver: %s, err: %s", cpeInNvd.VersionStartExcluding, err)
 			return "", err
 		}
-		constraints = append(constraints, "> "+dict.VersionStartExcluding)
+		constraints = append(constraints, "> "+cpeInNvd.VersionStartExcluding)
 	}
-	if dict.VersionEndIncluding != "" {
-		_, err := version.NewSemver(dict.VersionEndIncluding)
+	if cpeInNvd.VersionEndIncluding != "" {
+		_, err := version.NewSemver(cpeInNvd.VersionEndIncluding)
 		if err != nil {
-			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionEndIncluding, err)
+			log.Debugf("Failed to parse the semver: %s, err: %s", cpeInNvd.VersionEndIncluding, err)
 			return "", err
 		}
-		constraints = append(constraints, "<= "+dict.VersionEndIncluding)
+		constraints = append(constraints, "<= "+cpeInNvd.VersionEndIncluding)
 	}
-	if dict.VersionEndExcluding != "" {
-		_, err := version.NewSemver(dict.VersionEndExcluding)
+	if cpeInNvd.VersionEndExcluding != "" {
+		_, err := version.NewSemver(cpeInNvd.VersionEndExcluding)
 		if err != nil {
-			log.Debugf("Failed to parse the semver: %s, err: %s", dict.VersionEndExcluding, err)
+			log.Debugf("Failed to parse the semver: %s, err: %s", cpeInNvd.VersionEndExcluding, err)
 			return "", err
 		}
-		constraints = append(constraints, "< "+dict.VersionEndExcluding)
+		constraints = append(constraints, "< "+cpeInNvd.VersionEndExcluding)
 	}
 	return strings.Join(constraints, ", "), nil
 }
@@ -218,6 +218,8 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 		ok, err := matchSemver(specifiedVer, cpeInNvd)
 		if err != nil {
 			// version range specified in cpeInNvd are not defined as semver style
+			// So, we assume it is in rpm format and try to check the version.
+			// False positives will occur if they do not fit into the rpm version comparison method.
 			if ok := matchRpmVer(specifiedVer, cpeInNvd); ok {
 				return isSuperORSubset(cpeInNvdWfn, specified), nil
 			}

--- a/db/db.go
+++ b/db/db.go
@@ -185,35 +185,35 @@ func isSamePartVendorProduct(cpeA, cpeB string) (bool, error) {
 	return false, nil
 }
 
-func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
+func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRoughVerMatch, isVendorProductMatch bool, err error) {
 	specified, err := naming.UnbindURI(specifiedURI)
 	if err != nil {
-		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", specifiedURI, err)
+		return false, false, false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", specifiedURI, err)
 	}
 
 	cpeInNvdWfn, err := naming.UnbindURI(cpeInNvd.URI)
 	if err != nil {
-		return false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeInNvd.URI, err)
+		return false, false, false, xerrors.Errorf("Failed to unbind. CPE: %s. err: %w", cpeInNvd.URI, err)
 	}
 
 	if cpeInNvdWfn.Get(common.AttributePart) != specified.Get(common.AttributePart) ||
 		cpeInNvdWfn.Get(common.AttributeVendor) != specified.Get(common.AttributeVendor) ||
 		cpeInNvdWfn.Get(common.AttributeProduct) != specified.Get(common.AttributeProduct) {
-		return false, nil
+		return false, false, false, nil
 	}
 
 	if matching.IsEqual(specified, cpeInNvdWfn) {
 		log.Debugf("%s equals %s", specified.String(), cpeInNvd.URI)
-		return true, nil
+		return true, false, false, nil
 	}
 
 	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
 	switch specifiedVer {
 	case "NA", "ANY":
 		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
-			return false, err
+			return false, false, false, err
 		}
-		return isSuperORSubset(cpeInNvdWfn, specified), nil
+		return false, false, isSuperORSubset(cpeInNvdWfn, specified), nil
 	default:
 		ok, err := matchSemver(specifiedVer, cpeInNvd)
 		if err != nil {
@@ -221,11 +221,11 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 			// So, we assume it is in rpm format and try to check the version.
 			// False positives will occur if they do not fit into the rpm version comparison method.
 			if ok := matchRpmVer(specifiedVer, cpeInNvd); ok {
-				return isSuperORSubset(cpeInNvdWfn, specified), nil
+				return false, isSuperORSubset(cpeInNvdWfn, specified), false, nil
 			}
 		}
 		if ok {
-			return isSuperORSubset(cpeInNvdWfn, specified), nil
+			return isSuperORSubset(cpeInNvdWfn, specified), false, false, nil
 		}
 
 		// If the specified version is not as a range, but as a fixed value
@@ -239,15 +239,15 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (bool, error) {
 		// - AffectedCPEInNVD:    "cpe:/a:apache:cordova:5.1.1::~~~android~~",
 		if fmt.Sprintf("%s", specified.Get(common.AttributeVersion)) !=
 			fmt.Sprintf("%s", cpeInNvdWfn.Get(common.AttributeVersion)) {
-			return false, nil
+			return false, false, false, nil
 		}
 		if err := cpeInNvdWfn.Set(common.AttributeVersion, nil); err != nil {
-			return false, err
+			return false, false, false, err
 		}
 		if err := specified.Set(common.AttributeVersion, nil); err != nil {
-			return false, err
+			return false, false, false, err
 		}
-		return isSuperORSubset(cpeInNvdWfn, specified), nil
+		return isSuperORSubset(cpeInNvdWfn, specified), false, false, nil
 	}
 }
 
@@ -313,22 +313,22 @@ func matchRpmVer(specifiedVer string, cpeInNvd models.CpeBase) bool {
 func matchCpe(uri string, cve *models.CveDetail) (nvdMatch, jvnMatch bool, err error) {
 	for _, nvd := range cve.Nvds {
 		for _, cpe := range nvd.Cpes {
-			match, err := match(uri, cpe.CpeBase)
+			isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
 			if err != nil {
 				log.Debugf("Failed to match: %s", err)
 				continue
-			} else if match {
+			} else if isExactMatch || isRoughMatch || isVendorProductMatch {
 				return true, false, nil
 			}
 		}
 	}
 
-	// CPE that exists only in JVN is also detected.
-	// There is a possibility of false positives since the JVN does not contain version information.
 	if !cve.HasJvn() {
 		return false, false, nil
 	}
 
+	// CPE that exists only in JVN is also detected.
+	// There is a possibility of false positives since the JVN does not contain version information.
 	for _, jvn := range cve.Jvns {
 		for _, jvnCpe := range jvn.Cpes {
 			// If NVD has data of the same `part`, `vendor`, and `product`, NVD is used in priority.
@@ -391,11 +391,18 @@ func filterCveDetailByCpeURI(uri string, d *models.CveDetail) error {
 	d.Nvds = []models.Nvd{}
 	for _, nvd := range nvds {
 		for _, cpe := range nvd.Cpes {
-			matched, err := match(uri, cpe.CpeBase)
+			isExactMatch, isRoughMatch, isVendorProductMatch, err := match(uri, cpe.CpeBase)
 			if err != nil {
 				log.Debugf("Failed to match. err: %s, uri: %s, CpeBase: %#v", err, uri, cpe.CpeBase)
 			}
-			if matched {
+			if isExactMatch {
+				nvd.DetectionMethod = models.NvdExactVersionMatch
+			} else if isRoughMatch {
+				nvd.DetectionMethod = models.NvdRoughVersionMatch
+			} else if isVendorProductMatch {
+				nvd.DetectionMethod = models.NvdVendorProductMatch
+			}
+			if isExactMatch || isRoughMatch || isVendorProductMatch {
 				d.Nvds = append(d.Nvds, nvd)
 				break
 			}
@@ -411,6 +418,7 @@ func filterCveDetailByCpeURI(uri string, d *models.CveDetail) error {
 				continue
 			}
 			if matched {
+				jvn.DetectionMethod = models.JvnVendorProductMatch
 				d.Jvns = append(d.Jvns, jvn)
 				break
 			}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -15,111 +15,124 @@ func TestMain(m *testing.M) {
 
 func TestMatch(t *testing.T) {
 	var testdata = []struct {
-		name  string
-		uri   string
-		cpe   models.CpeBase
-		match bool
-		err   bool
+		name                     string
+		uri                      string
+		cpe                      models.CpeBase
+		wantIsExactVerMatch      bool
+		wantIsRoughVerMatch      bool
+		wantIsVendorProductMatch bool
+		wantErr                  bool
 	}{
-		//0
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.1.1",
+			name: "true: exactMatch",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.1.1",
 			cpe: models.CpeBase{
 				URI:                   "cpe:/a:oracle:vm_virtualbox",
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.32",
 			},
-			match: true,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
-		//1
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.0.9",
+			name: "false: exactMatch",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.0.9",
 			cpe: models.CpeBase{
 				URI:                   "cpe:/a:oracle:vm_virtualbox",
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.32",
 			},
-			match: false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
-		//2
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.1.0",
+			name: "true: exactMatch ver == start",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.1.0",
 			cpe: models.CpeBase{
 				URI:                   "cpe:/a:oracle:vm_virtualbox",
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.32",
 			},
-			match: true,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
-		//3
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.2.32",
+			name: "false: exactMatch end < ver",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.2.32",
 			cpe: models.CpeBase{
 				URI:                   "cpe:/a:oracle:vm_virtualbox",
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.32",
 			},
-			match: false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
-		//4
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
+			name: "true: exactMatch start < ver < end",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.1.31",
 			cpe: models.CpeBase{
 				URI:                   "cpe:/a:oracle:vm_virtualbox",
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.32",
 			},
-			match: true,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
-		//5
 		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
+			name: "true: exactMatch ver == ver",
+			uri:  "cpe:/a:oracle:vm_virtualbox:5.1.31",
 			cpe: models.CpeBase{
 				URI: "cpe:/a:oracle:vm_virtualbox:5.1.31",
 			},
-			match: true,
-		},
-		//
-		{
-			uri: "cpe:/a:oracle:vm_virtualbox:5.1.31",
-			cpe: models.CpeBase{
-				URI: "cpe:/a:oracle:vm_virtualbox:5.1.31",
-			},
-			match: true,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
-			name: "superset",
+			name: "true: RoughMatch superset",
 			uri:  "cpe:/o:microsoft:windows_7",
 			cpe: models.CpeBase{
 				URI: "cpe:/o:microsoft:windows_7::sp1",
 			},
-			match: true,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: true,
 		},
 		{
-			name: "subset",
+			name: "true: RoughMatch subset",
 			uri:  "cpe:/o:microsoft:windows_7::sp2",
 			cpe: models.CpeBase{
 				URI: "cpe:/o:microsoft:windows_7",
 			},
-			match: true,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: true,
 		},
 		{
-			name: "subset",
+			name: "true: RoughMatch subset",
 			uri:  "cpe:/o:microsoft:windows_10",
 			cpe: models.CpeBase{
 				URI: "cpe:/o:microsoft:windows_10:-",
 			},
-			match: true,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: true,
 		},
 		{
-			//TODO
-			name: "no semver format",
+			name: "false: RoughMatch no semver format",
 			uri:  "cpe:/a:cisco:ios:15.2%282%29eb",
 			cpe: models.CpeBase{
 				URI: "cpe:/a:cisco:ios:15.2%282%29ec",
 			},
-			match: false,
-			err:   true,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
+			wantErr:                  false,
 		},
 		{
 			name: "malformed constraint",
@@ -129,8 +142,34 @@ func TestMatch(t *testing.T) {
 				VersionStartIncluding: "7.0.0",
 				VersionEndExcluding:   "esxi70u1c-17325551",
 			},
-			match: false,
-			err:   true,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
+			wantErr:                  false,
+		},
+		{
+			name: "true: RoughMatch no semver format",
+			uri:  "cpe:/a:openssl:openssl:1.1.1c",
+			cpe: models.CpeBase{
+				URI:                   "cpe:/a:openssl:openssl",
+				VersionStartIncluding: "1.1.1",
+				VersionEndExcluding:   "1.1.1l",
+			},
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      true,
+			wantIsVendorProductMatch: false,
+		},
+		{
+			name: "false: RoughMatch no semver format",
+			uri:  "cpe:/a:openssl:openssl:1.1.1n",
+			cpe: models.CpeBase{
+				URI:                   "cpe:/a:openssl:openssl",
+				VersionStartIncluding: "1.1.1",
+				VersionEndExcluding:   "1.1.1l",
+			},
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		// targetSW
 		{
@@ -139,8 +178,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1::~~~iphone_os~~",
 			},
-			match: true,
-			err:   false,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 2",
@@ -148,8 +188,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1::~~~android~~",
 			},
-			match: false,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 2.1",
@@ -157,8 +198,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.2::~~~android~~",
 			},
-			match: false,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 2.2",
@@ -166,8 +208,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.2",
 			},
-			match: false,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 2.3",
@@ -175,8 +218,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1",
 			},
-			match: true,
-			err:   false,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 3",
@@ -184,8 +228,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1",
 			},
-			match: true,
-			err:   false,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 4",
@@ -193,8 +238,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1",
 			},
-			match: true,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: true,
 		},
 		{
 			name: "targetSW: 5",
@@ -202,8 +248,9 @@ func TestMatch(t *testing.T) {
 			cpe: models.CpeBase{
 				URI: "cpe:/a:apache:cordova:5.1.1::~~~android~~",
 			},
-			match: false,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 6",
@@ -213,8 +260,9 @@ func TestMatch(t *testing.T) {
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.2",
 			},
-			match: true,
-			err:   false,
+			wantIsExactVerMatch:      true,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 		{
 			name: "targetSW: 7",
@@ -224,19 +272,26 @@ func TestMatch(t *testing.T) {
 				VersionStartIncluding: "5.1.0",
 				VersionEndExcluding:   "5.1.2",
 			},
-			match: false,
-			err:   false,
+			wantIsExactVerMatch:      false,
+			wantIsRoughVerMatch:      false,
+			wantIsVendorProductMatch: false,
 		},
 	}
 
-	for i, tt := range testdata {
-		match, err := match(tt.uri, tt.cpe)
-		if !tt.err && err != nil {
-			t.Errorf("[%d] err: %s", i, err)
+	for _, tt := range testdata {
+		gotIsExactVerMatch, gotIsRoughVerMatch, gotIsVendorProductMatch, err := match(tt.uri, tt.cpe)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("match():%s error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			return
 		}
-
-		if tt.match != match {
-			t.Errorf("[%d] name: %s, expected: %t, actual: %t", i, tt.name, tt.match, match)
+		if gotIsExactVerMatch != tt.wantIsExactVerMatch {
+			t.Errorf("match():%s gotIsExactVerMatch = %v, want %v", tt.name, gotIsExactVerMatch, tt.wantIsExactVerMatch)
+		}
+		if gotIsRoughVerMatch != tt.wantIsRoughVerMatch {
+			t.Errorf("match():%s gotIsRoughVerMatch = %v, want %v", tt.name, gotIsRoughVerMatch, tt.wantIsRoughVerMatch)
+		}
+		if gotIsVendorProductMatch != tt.wantIsVendorProductMatch {
+			t.Errorf("match():%s gotIsVendorProductMatch = %v, want %v", tt.name, gotIsVendorProductMatch, tt.wantIsVendorProductMatch)
 		}
 	}
 }
@@ -407,12 +462,13 @@ func Test_matchCpe(t *testing.T) {
 	}
 }
 
-func Test_filterCveDetailByCpeURI(t *testing.T) {
+func Test_filterCveDetailByCpeURI1(t *testing.T) {
 	type args struct {
 		uri string
 		cve *models.CveDetail
 	}
 	tests := []struct {
+		name     string
 		args     args
 		expected *models.CveDetail
 	}{
@@ -456,6 +512,7 @@ func Test_filterCveDetailByCpeURI(t *testing.T) {
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
 						},
+						DetectionMethod: models.NvdExactVersionMatch,
 					},
 				},
 				Jvns: []models.Jvn{
@@ -463,6 +520,7 @@ func Test_filterCveDetailByCpeURI(t *testing.T) {
 						Cpes: []models.JvnCpe{
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
 						},
+						DetectionMethod: models.JvnVendorProductMatch,
 					},
 				},
 			},
@@ -500,6 +558,7 @@ func Test_filterCveDetailByCpeURI(t *testing.T) {
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
 						},
+						DetectionMethod: models.NvdVendorProductMatch,
 					},
 				},
 				Jvns: []models.Jvn{
@@ -507,6 +566,7 @@ func Test_filterCveDetailByCpeURI(t *testing.T) {
 						Cpes: []models.JvnCpe{
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product"}},
 						},
+						DetectionMethod: models.JvnVendorProductMatch,
 					},
 				},
 			},
@@ -534,12 +594,78 @@ func Test_filterCveDetailByCpeURI(t *testing.T) {
 				Jvns: []models.Jvn{},
 			},
 		},
+		{
+
+			name: "NvdRoughVersionMatch",
+			args: args{
+				uri: "cpe:/o:vendor:product:1.0.0c",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{{Cpes: []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.0n"}}}}},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{
+					{
+						Cpes:            []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.0n"}}},
+						DetectionMethod: models.NvdRoughVersionMatch,
+					},
+				},
+				Jvns: []models.Jvn{},
+			},
+		},
+		{
+
+			name: "NvdRoughVersionMatch false",
+			args: args{
+				uri: "cpe:/o:vendor:product:1.1.0c",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{{Cpes: []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.0n"}}}}},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{},
+				Jvns: []models.Jvn{},
+			},
+		},
+		{
+
+			name: "NvdExactMatch semver true",
+			args: args{
+				uri: "cpe:/o:vendor:product:1.0.3",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{{Cpes: []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.10"}}}}},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{
+					{
+						Cpes:            []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.10"}}},
+						DetectionMethod: models.NvdExactVersionMatch,
+					},
+				},
+				Jvns: []models.Jvn{},
+			},
+		},
+		{
+
+			name: "NvdExactMatch semver false",
+			args: args{
+				uri: "cpe:/o:vendor:product:2.0.0",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{{Cpes: []models.NvdCpe{{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product", VersionStartIncluding: "1.0.0", VersionEndExcluding: "1.0.10"}}}}},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{},
+				Jvns: []models.Jvn{},
+			},
+		},
 	}
 
 	for i, tt := range tests {
 		_ = filterCveDetailByCpeURI(tt.args.uri, tt.args.cve)
 		if !reflect.DeepEqual(tt.args.cve, tt.expected) {
-			t.Errorf("[%d] expected: %+v, actual: %+v", i, tt.expected, tt.args.cve)
+			t.Errorf("[%d] expected: %#v, actual: %#v", i, tt.expected, tt.args.cve)
 		}
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -9,97 +9,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// log.Initialize("/tmp", true, os.Stderr)
 	code := m.Run()
 	os.Exit(code)
 }
 
-// move to rdb_test.go
-func TestMakeVersionConstraint(t *testing.T) {
-	var testdata = []struct {
-		cpe        models.CpeBase
-		constraint string
-	}{
-		{
-			cpe: models.CpeBase{
-				CpeWFN: models.CpeWFN{
-					Part:            "a",
-					Vendor:          "cisco",
-					Product:         "node-jose",
-					Version:         "",
-					Update:          "",
-					Edition:         "",
-					Language:        "",
-					SoftwareEdition: "",
-					TargetSW:        "",
-					TargetHW:        "",
-					Other:           "",
-				},
-				VersionStartExcluding: "",
-				VersionStartIncluding: "",
-				VersionEndExcluding:   "0.11.0",
-				VersionEndIncluding:   "",
-			},
-			constraint: "< 0.11.0",
-		},
-		{
-			cpe: models.CpeBase{
-				CpeWFN: models.CpeWFN{
-					Part:    "a",
-					Vendor:  "cisco",
-					Product: "node-jose",
-				},
-				VersionEndIncluding: "0.11.0",
-			},
-			constraint: "<= 0.11.0",
-		},
-		{
-			cpe: models.CpeBase{
-				CpeWFN: models.CpeWFN{
-					Part:    "a",
-					Vendor:  "cisco",
-					Product: "node-jose",
-				},
-				VersionStartExcluding: "0.10.0",
-				VersionEndIncluding:   "0.11.0",
-			},
-			constraint: "> 0.10.0, <= 0.11.0",
-		},
-		{
-			cpe: models.CpeBase{
-				CpeWFN: models.CpeWFN{
-					Part:    "a",
-					Vendor:  "cisco",
-					Product: "node-jose",
-				},
-				VersionStartIncluding: "0.10.0",
-				VersionEndExcluding:   "0.11.0",
-			},
-			constraint: ">= 0.10.0, < 0.11.0",
-		},
-		{
-			cpe: models.CpeBase{
-				CpeWFN: models.CpeWFN{
-					Part:    "a",
-					Vendor:  "cisco",
-					Product: "node-jose",
-				},
-				VersionStartIncluding: "",
-				VersionEndExcluding:   "",
-			},
-			constraint: "",
-		},
-	}
-
-	for i, tt := range testdata {
-		constraint := makeVersionConstraint(tt.cpe)
-		if tt.constraint != constraint {
-			t.Errorf("[%d] expected %s, actual %s", i, tt.constraint, constraint)
-		}
-	}
-}
-
-// move to rdb_test.go
 func TestMatch(t *testing.T) {
 	var testdata = []struct {
 		name  string
@@ -328,47 +241,6 @@ func TestMatch(t *testing.T) {
 	}
 }
 
-func TestMatchProductVendor(t *testing.T) {
-	var testdata = []struct {
-		uri     string
-		affects []models.NvdAffect
-		match   bool
-	}{
-		{
-			uri: "cpe:/o:cisco:nx-os:6.0%282%29a6%288%29",
-			affects: []models.NvdAffect{
-				{
-					Vendor:  "cisco",
-					Product: "nx-os",
-					Version: "6.0(2)a6(8)",
-				},
-			},
-			match: true,
-		},
-		{
-			uri: "cpe:/o:cisco:nx-os:6.0%282%29a6%288%29",
-			affects: []models.NvdAffect{
-				{
-					Vendor:  "cisco",
-					Product: "nx-os",
-					Version: "7.0(2)a6(8)",
-				},
-			},
-			match: false,
-		},
-	}
-	for i, tt := range testdata {
-		match, err := matchExactByAffects(tt.uri, tt.affects)
-		if err != nil {
-			t.Errorf("[%d] err: %s", i, err)
-		}
-
-		if tt.match != match {
-			t.Errorf("[%d] expected: %t, actual: %t", i, tt.match, match)
-		}
-	}
-}
-
 func Test_matchCpe(t *testing.T) {
 	nvdRangeCpe := models.NvdCpe{
 		NvdID: 1,
@@ -383,17 +255,17 @@ func Test_matchCpe(t *testing.T) {
 			VersionEndIncluding:   "2.0.0",
 		},
 	}
-	nvdNonSemVerCpe := models.NvdCpe{
+	nvdRangeNoSemver := models.NvdCpe{
 		NvdID: 1,
 		CpeBase: models.CpeBase{
-			URI: "cpe:/o:qualcomm:qcs605_firmware",
+			URI: "cpe:/a:openssl:openssl",
 			CpeWFN: models.CpeWFN{
-				Part:    "o",
-				Vendor:  "qualcomm",
-				Product: "qcs605_firmware",
+				Part:    "a",
+				Vendor:  "openssl",
+				Product: "openssl",
 			},
-			VersionStartIncluding: "hoge",
-			VersionEndIncluding:   "hoge",
+			VersionStartIncluding: "1.1.1a",
+			VersionEndIncluding:   "1.1.1c",
 		},
 	}
 	jvnCpe := models.JvnCpe{
@@ -419,7 +291,7 @@ func Test_matchCpe(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "nvd range match",
+			name: "nvd range match semver",
 			args: args{
 				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
 				cve: &models.CveDetail{
@@ -432,7 +304,7 @@ func Test_matchCpe(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nvd range not match",
+			name: "nvd range not match semver",
 			args: args{
 				uri: "cpe:/o:qualcomm:qcs605_firmware:3.0.0",
 				cve: &models.CveDetail{
@@ -445,19 +317,12 @@ func Test_matchCpe(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nvd affect match",
+			name: "nvd range match non-semver",
 			args: args{
-				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				uri: "cpe:/a:openssl:openssl:1.1.1b",
 				cve: &models.CveDetail{
 					Nvds: []models.Nvd{{
-						Cpes: []models.NvdCpe{nvdNonSemVerCpe},
-						Affects: []models.NvdAffect{
-							{
-								Vendor:  "qualcomm",
-								Product: "qcs605_firmware",
-								Version: "1.0.0",
-							},
-						}},
+						Cpes: []models.NvdCpe{nvdRangeNoSemver}},
 					},
 				},
 			},
@@ -465,19 +330,12 @@ func Test_matchCpe(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nvd affects not match",
+			name: "nvd range not match non-semver",
 			args: args{
-				uri: "cpe:/o:qualcomm:qcs605_firmware:1.0.0",
+				uri: "cpe:/a:openssl:openssl:1.1.1l",
 				cve: &models.CveDetail{
 					Nvds: []models.Nvd{{
-						Cpes: []models.NvdCpe{nvdNonSemVerCpe},
-						Affects: []models.NvdAffect{
-							{
-								Vendor:  "qualcomm",
-								Product: "qcs605_firmware",
-								Version: "1.0.1",
-							},
-						}},
+						Cpes: []models.NvdCpe{nvdRangeNoSemver}},
 					},
 				},
 			},
@@ -536,20 +394,20 @@ func Test_matchCpe(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			nvdGot, jvnGot, err := matchCpe(tt.args.uri, tt.args.cve)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("matchCpe() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("%s error = %v, wantErr %v", tt.name, err, tt.wantErr)
 				return
 			}
 			if nvdGot != tt.nvdWant {
-				t.Errorf("matchCpe() nvd = %v, want %v", nvdGot, tt.nvdWant)
+				t.Errorf("%s matchCpe() nvd = %v, want %v", tt.name, nvdGot, tt.nvdWant)
 			}
 			if jvnGot != tt.jvnWant {
-				t.Errorf("matchCpe() jvn = %v, want %v", jvnGot, tt.jvnWant)
+				t.Errorf("%s matchCpe() jvn = %v, want %v", tt.name, jvnGot, tt.jvnWant)
 			}
 		})
 	}
 }
 
-func Test_filterCVEDetailbyCPEURI(t *testing.T) {
+func Test_filterCveDetailByCpeURI(t *testing.T) {
 	type args struct {
 		uri string
 		cve *models.CveDetail
@@ -683,5 +541,438 @@ func Test_filterCVEDetailbyCPEURI(t *testing.T) {
 		if !reflect.DeepEqual(tt.args.cve, tt.expected) {
 			t.Errorf("[%d] expected: %+v, actual: %+v", i, tt.expected, tt.args.cve)
 		}
+	}
+}
+
+func Test_makeVersionConstraint(t *testing.T) {
+	type args struct {
+		dict models.CpeBase
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single <",
+			args: args{
+				dict: models.CpeBase{
+					CpeWFN: models.CpeWFN{
+						Part:    "a",
+						Vendor:  "cisco",
+						Product: "node-jose",
+					},
+					VersionEndExcluding: "0.11.0",
+				},
+			},
+			want:    "< 0.11.0",
+			wantErr: false,
+		},
+		{
+			name: "single <=",
+			args: args{
+				dict: models.CpeBase{
+					CpeWFN: models.CpeWFN{
+						Part:    "a",
+						Vendor:  "cisco",
+						Product: "node-jose",
+					},
+					VersionEndIncluding: "0.11.0",
+				},
+			},
+			want:    "<= 0.11.0",
+			wantErr: false,
+		},
+		{
+			name: "> and <=",
+			args: args{
+				dict: models.CpeBase{
+					CpeWFN: models.CpeWFN{
+						Part:    "a",
+						Vendor:  "cisco",
+						Product: "node-jose",
+					},
+					VersionStartExcluding: "0.10.0",
+					VersionEndIncluding:   "0.11.0",
+				},
+			},
+			want:    "> 0.10.0, <= 0.11.0",
+			wantErr: false,
+		},
+		{
+			name: ">= and <",
+			args: args{
+				dict: models.CpeBase{
+					CpeWFN: models.CpeWFN{
+						Part:    "a",
+						Vendor:  "cisco",
+						Product: "node-jose",
+					},
+					VersionStartIncluding: "0.10.0",
+					VersionEndExcluding:   "0.11.0",
+				},
+			},
+			want:    ">= 0.10.0, < 0.11.0",
+			wantErr: false,
+		},
+		{
+			name: "version not specified",
+			args: args{
+				dict: models.CpeBase{
+					CpeWFN: models.CpeWFN{
+						Part:    "a",
+						Vendor:  "cisco",
+						Product: "node-jose",
+					},
+				},
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "err if VersionStartIncluding is not a semver style",
+			args: args{
+				dict: models.CpeBase{
+					VersionStartIncluding: "1.1.1l",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "err if VersionStartExcluding is not a semver style",
+			args: args{
+				dict: models.CpeBase{
+					VersionStartExcluding: "1.1.1l",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "err if VersionEndIncluding is not a semver style",
+			args: args{
+				dict: models.CpeBase{
+					VersionEndIncluding: "1.1.1l",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "err if VersionEndExcluding is not a semver style",
+			args: args{
+				dict: models.CpeBase{
+					VersionEndExcluding: "1.1.1l",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeVersionConstraint(tt.args.dict)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("makeVersionConstraint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("makeVersionConstraint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_matchSemver(t *testing.T) {
+	type args struct {
+		specifiedVer string
+		cpeInNvd     models.CpeBase
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantOk  bool
+		wantErr bool
+	}{
+		{
+			name: "empty string return false, nil",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name: "return err if range is not a semver style",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.1l",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  false,
+			wantErr: true,
+		},
+		{
+			name: "< specified",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.2",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name: "< specified",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.1",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name: "<= specified",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "1.1.1",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name: "specified <",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "1.1.1",
+					VersionEndIncluding:   "",
+				},
+			},
+			wantOk:  false,
+			wantErr: false,
+		},
+		{
+			name: "specified <=",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "1.1.1",
+				},
+			},
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name: "specified <=",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "1.1.0",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "1.1.2",
+				},
+			},
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name: "err if range in nvd is not a semver style",
+			args: args{
+				specifiedVer: "1.1.1",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "",
+					VersionStartIncluding: "1.1.0l",
+					VersionEndExcluding:   "",
+					VersionEndIncluding:   "1.1.2",
+				},
+			},
+			wantOk:  false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOk, err := matchSemver(tt.args.specifiedVer, tt.args.cpeInNvd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("matchSemver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotOk != tt.wantOk {
+				t.Errorf("matchSemver() = %v, want %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}
+
+func Test_matchRpmVer(t *testing.T) {
+	type args struct {
+		specifiedVer string
+		cpeInNvd     models.CpeBase
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// VersionStartIncluding
+		{
+			name: "specified == VersionStartIncluding",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartIncluding: "1.1.1a",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VersionStartIncluding < specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartIncluding: "1.1.0a",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VersionStartIncluding > specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartIncluding: "1.1.1b",
+				},
+			},
+			want: false,
+		},
+		// VersionStartExcluding
+		{
+			name: "specified == VersionStartExcluding",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.1a",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "VersionStartExcluding < specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.0z",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VersionStartExcluding > specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionStartExcluding: "1.1.1b",
+				},
+			},
+			want: false,
+		},
+		// VersionEndIncluding
+		{
+			name: "specified == VersionEndIncluding",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndIncluding: "1.1.1a",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "VersionEndIncluding < specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndIncluding: "1.1.0z",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "VersionEndIncluding > specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndIncluding: "1.1.1b",
+				},
+			},
+			want: true,
+		},
+		// VersionEndExcluding
+		{
+			name: "specified == VersionEndExcluding",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndExcluding: "1.1.1a",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "VersionEndExcluding < specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndExcluding: "1.1.0z",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "VersionEndExcluding> specified",
+			args: args{
+				specifiedVer: "1.1.1a",
+				cpeInNvd: models.CpeBase{
+					VersionEndExcluding: "1.1.1b",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchRpmVer(tt.args.specifiedVer, tt.args.cpeInNvd); got != tt.want {
+				t.Errorf("matchRpmVer() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -122,7 +122,6 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.NvdCwe{},
 		&models.NvdCpe{},
 		&models.NvdEnvCpe{},
-		&models.NvdAffect{},
 		&models.NvdReference{},
 		&models.NvdCert{},
 

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -208,7 +208,6 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Preload("Cwes").
 		Preload("Cpes").
 		Preload("Cpes.EnvCpes").
-		Preload("Affects").
 		Preload("References").
 		Preload("Certs").
 		Find(&detail.Nvds).Error
@@ -500,7 +499,7 @@ func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, feedMetaID uint, cves []mo
 			}
 
 			if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).
-				Select("Descriptions", "Cvss2", "Cvss3", "Cwes", "Cpes", "Affects", "References", "Certs").
+				Select("Descriptions", "Cvss2", "Cvss3", "Cwes", "Cpes", "References", "Certs").
 				Delete(olds[idx.From:idx.To]).Error; err != nil {
 				return err
 			}

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -159,9 +159,9 @@ func FetchLatestFeedMeta(driver db.DB, years []int) (metas []models.FeedMeta, er
 
 		for _, latestMeta := range latestMetas {
 			if latestMeta.URL == url {
-				y, err := models.GetYearbyURL(models.JvnType, url)
+				y, err := models.GetYearByURL(models.JvnType, url)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to GetYearbyURL. err: %s", err)
+					return nil, fmt.Errorf("Failed to GetYearByURL. err: %s", err)
 				}
 
 				meta.URL = url
@@ -223,9 +223,9 @@ func fetch(metas []models.FeedMeta) (map[string][]Item, error) {
 			}
 		}
 
-		y, err := models.GetYearbyURL(models.JvnType, res.URL)
+		y, err := models.GetYearByURL(models.JvnType, res.URL)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to GetYearbyURL. err: %s", err)
+			return nil, fmt.Errorf("Failed to GetYearByURL. err: %s", err)
 		}
 		fetchedItems[y] = items
 	}

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -157,23 +157,6 @@ type CveItem struct {
 			ID       string `json:"ID"`
 			ASSIGNER string `json:"ASSIGNER"`
 		} `json:"CVE_data_meta"`
-		Affects struct {
-			Vendor struct {
-				VendorData []struct {
-					VendorName string `json:"vendor_name"`
-					Product    struct {
-						ProductData []struct {
-							ProductName string `json:"product_name"`
-							Version     struct {
-								VersionData []struct {
-									VersionValue string `json:"version_value"`
-								} `json:"version_data"`
-							} `json:"version"`
-						} `json:"product_data"`
-					} `json:"product"`
-				} `json:"vendor_data"`
-			} `json:"vendor"`
-		} `json:"affects"`
 		Problemtype struct {
 			ProblemtypeData []struct {
 				Description []struct {

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -79,9 +79,9 @@ func fetch(metas []models.FeedMeta) (map[string][]CveItem, error) {
 			}
 		}
 
-		y, err := models.GetYearbyURL(models.NvdType, res.URL)
+		y, err := models.GetYearByURL(models.NvdType, res.URL)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to GetYearbyURL. err: %s", err)
+			return nil, fmt.Errorf("Failed to GetYearByURL. err: %s", err)
 		}
 
 		items[y] = nvd.CveItems
@@ -312,22 +312,6 @@ func convertToModel(item *CveItem) (*models.Nvd, error) {
 	}
 
 	full := viper.GetBool("full")
-	affects := []models.NvdAffect{}
-	// Affects
-	if full {
-		for _, vendor := range item.Cve.Affects.Vendor.VendorData {
-			for _, prod := range vendor.Product.ProductData {
-				for _, version := range prod.Version.VersionData {
-					affects = append(affects, models.NvdAffect{
-						Vendor:  vendor.VendorName,
-						Product: prod.ProductName,
-						Version: version.VersionValue,
-					})
-				}
-			}
-		}
-	}
-
 	cpes := []models.NvdCpe{}
 	for _, node := range item.Configurations.Nodes {
 		if node.Negate {
@@ -477,7 +461,6 @@ func convertToModel(item *CveItem) (*models.Nvd, error) {
 		Cwes:             cwes,
 		Cpes:             cpes,
 		References:       refs,
-		Affects:          affects,
 		Certs:            certs,
 		PublishedDate:    publish,
 		LastModifiedDate: modified,

--- a/fetcher/nvd/util.go
+++ b/fetcher/nvd/util.go
@@ -66,7 +66,7 @@ func nvdFeedURLToYear(url string) (year int, err error) {
 	default:
 		y, err := strconv.Atoi(yearstr)
 		if err != nil {
-			return 0, fmt.Errorf("Unable conver to int: %d, err: %s",
+			return 0, fmt.Errorf("Unable convert to int: %d, err: %s",
 				year, err)
 		}
 		return y, nil
@@ -107,9 +107,9 @@ func FetchLatestFeedMeta(driver db.DB, years []int) (metas []models.FeedMeta, er
 				res.Year, err)
 		}
 
-		y, err := models.GetYearbyURL(models.NvdType, url)
+		y, err := models.GetYearByURL(models.NvdType, url)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to GetYearbyURL. err: %s", err)
+			return nil, fmt.Errorf("Failed to GetYearByURL. err: %s", err)
 		}
 
 		meta.URL = url

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f
+	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f h1:vZP1dTKPOR7zSAbgqNbnTnYX77+gj3eu0QK+UmANZqE=
 github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f/go.mod h1:4cVhzV/TndScEg4xMtSo3TTz3cMFhEAvhAA4igAyXZY=
+github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 h1:HDjRqotkViMNcGMGicb7cgxklx8OwnjtCBmyWEqrRvM=
+github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/models/models.go
+++ b/models/models.go
@@ -57,6 +57,15 @@ const (
 	NvdType = "NVD"
 	// JvnType :
 	JvnType = "JVN"
+
+	// NvdExactVersionMatch :
+	NvdExactVersionMatch = "NvdExactVersionMatch"
+	// NvdRoughVersionMatch :
+	NvdRoughVersionMatch = "NvdRoughVersionMatch"
+	// NvdVendorProductMatch :
+	NvdVendorProductMatch = "NvdVendorProductMatch"
+	// JvnVendorProductMatch :
+	JvnVendorProductMatch = "JvnVendorProductMatch"
 )
 
 func (f FeedMeta) color(str string) string {
@@ -267,6 +276,8 @@ type Nvd struct {
 	Certs            []NvdCert
 	PublishedDate    time.Time
 	LastModifiedDate time.Time
+
+	DetectionMethod string `gorm:"-"`
 }
 
 // NvdDescription has description of the CVE
@@ -354,6 +365,8 @@ type Jvn struct {
 	Certs            []JvnCert
 	PublishedDate    time.Time
 	LastModifiedDate time.Time
+
+	DetectionMethod string `gorm:"-"`
 }
 
 // JvnCvss2 has Jvn CVSS Version 2 info

--- a/models/models.go
+++ b/models/models.go
@@ -90,8 +90,8 @@ func (f FeedMeta) FetchOption() (string, error) {
 	}
 }
 
-// GetYearbyURL returns year of the feed
-func GetYearbyURL(source, url string) (year string, err error) {
+// GetYearByURL returns year of the feed
+func GetYearByURL(source, url string) (year string, err error) {
 	switch source {
 	case NvdType:
 		return strings.TrimSuffix(
@@ -263,7 +263,6 @@ type Nvd struct {
 	Cvss3            NvdCvss3
 	Cwes             []NvdCwe
 	Cpes             []NvdCpe
-	Affects          []NvdAffect
 	References       []NvdReference
 	Certs            []NvdCert
 	PublishedDate    time.Time
@@ -323,15 +322,6 @@ type NvdEnvCpe struct {
 	ID       int64 `json:"-"`
 	NvdCpeID uint  `json:"-" gorm:"index:idx_nvd_env_cpes_nvd_cpe_id"`
 	CpeBase  `gorm:"embedded"`
-}
-
-// NvdAffect has vendor/product/version info in NVD
-type NvdAffect struct {
-	ID      int64  `json:"-"`
-	NvdID   uint   `json:"-" index:"idx_nvd_affects_nvd_id"`
-	Vendor  string `gorm:"type:varchar(255)"`
-	Product string `gorm:"type:varchar(255)"`
-	Version string `gorm:"type:varchar(255)"`
 }
 
 // NvdReference holds reference information about the CVE.


### PR DESCRIPTION
# What did you implement:

fixes #208 

https://nvd.nist.gov/vuln/data-feeds#JSON_FEED

In the JSON feed of the NVD, the information of the CPE corresponding to a certain CVE-ID is defined as follows.

 "ID" : "CVE-2018-0733",

```
    "configurations" : {
      "CVE_data_version" : "4.0",
      "nodes" : [ {
        "operator" : "OR",
        "cpe_match" : [ {
          "vulnerable" : true,
          "cpe23Uri" : "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*",
          "versionStartIncluding" : "1.1.0",
          "versionEndIncluding" : "1.1.0g"
        } ]
      } ]
    },
```

There are many well-known software packages that use non-semantic versioning, such as OpenSSL.

In the previous implementation, the comparison process failed when the version range was not in Semantic versioning format.
There was a problem of undetectability if it is not semantic versioning.
So, it is better that compared and processed as rpm format when the version in NVD is not in semantic versioning format.

However, the comparison assuming the rpm version format may lead to false positives, so applications using it should be aware of this.

Vuls will display a lower Confidence score.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The result of `make diff` is the intended one.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
