### PR TITLE
fix(rdb): avoid too many SQL variables

### DIFF
--- a/db/rdb.go
+++ b/db/rdb.go
@@ -212,7 +212,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Preload("References").
 		Preload("Certs").
 		Find(&detail.Nvds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, err
+		return nil, xerrors.Errorf("Failed to fill Nvd. Nvd{CveID: %s} err: %w", cveID, err)
 	}
 
 	for i := range detail.Nvds {
@@ -220,7 +220,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 			if err := r.conn.
 				Where(&models.NvdEnvCpe{NvdCpeID: uint(detail.Nvds[i].Cpes[j].ID)}).
 				Find(&detail.Nvds[i].Cpes[j].EnvCpes).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, err
+				return nil, xerrors.Errorf("Failed to fill Nvd EnvCpes. Nvd{CveID: %s} Cpes:{NvdCpeID: %d} err: %w", cveID, uint(detail.Nvds[i].Cpes[j].ID), err)
 			}
 		}
 	}
@@ -233,7 +233,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Preload("References").
 		Preload("Certs").
 		Find(&detail.Jvns).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, err
+		return nil, xerrors.Errorf("Failed to fill Jvn. Jvn{CveID: %s} err: %w", cveID, err)
 	}
 
 	return &detail, nil

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -201,31 +201,38 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 	detail := models.CveDetail{
 		CveID: cveID,
 	}
-	err := r.conn.
+	if err := r.conn.
 		Where(&models.Nvd{CveID: cveID}).
 		Preload("Descriptions").
 		Preload("Cvss2").
 		Preload("Cvss3").
 		Preload("Cwes").
 		Preload("Cpes").
-		Preload("Cpes.EnvCpes").
 		Preload("Affects").
 		Preload("References").
 		Preload("Certs").
-		Find(&detail.Nvds).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&detail.Nvds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 
-	err = r.conn.
+	for i := range detail.Nvds {
+		for j := range detail.Nvds[i].Cpes {
+			if err := r.conn.
+				Where(&models.NvdEnvCpe{NvdCpeID: uint(detail.Nvds[i].Cpes[j].ID)}).
+				Find(&detail.Nvds[i].Cpes[j].EnvCpes).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, err
+			}
+		}
+	}
+
+	if err := r.conn.
 		Where(&models.Jvn{CveID: cveID}).
 		Preload("Cvss2").
 		Preload("Cvss3").
 		Preload("Cpes").
 		Preload("References").
 		Preload("Certs").
-		Find(&detail.Jvns).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&detail.Jvns).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 
@@ -243,22 +250,20 @@ func (r *RDBDriver) getCveIDsByPartVendorProduct(uri string) ([]string, error) {
 	product := specified.GetString(common.AttributeProduct)
 
 	nvds := []models.Nvd{}
-	err = r.conn.
+	if err := r.conn.
 		Select("nvds.cve_id").
 		Joins("JOIN nvd_cpes ON nvd_cpes.nvd_id = nvds.id").
 		Where("nvd_cpes.part = ? AND nvd_cpes.vendor = ? AND nvd_cpes.product = ?", part, vendor, product).
-		Find(&nvds).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&nvds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 
 	jvns := []models.Jvn{}
-	err = r.conn.
+	if err := r.conn.
 		Select("jvns.cve_id").
 		Joins("JOIN jvn_cpes ON jvn_cpes.jvn_id = jvns.id").
 		Where("jvn_cpes.part = ? AND jvn_cpes.vendor = ? AND jvn_cpes.product = ?", part, vendor, product).
-		Find(&jvns).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		Find(&jvns).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 


### PR DESCRIPTION
# What did you implement:
[future-architect/vuls](https://github.com/future-architect/vuls) is reporting `too many SQL variables` error.
In order to avoid this, the EnvCpes part of the NVD is obtained with a for loop.

From the survey of the https://github.com/future-architect/vuls/issues/1295#issuecomment-909415220, the suspicious part seems to be the query that fills `nvd_env_cpes` when searching for CVE-2017-5715.
However, in go-cve-dictionary server mode, CVE-2017-5715 terminates successfully and a response is obtained.
```console
$ go-cve-dictionary server
{"time":"2021-09-01T05:14:24.68800381+09:00","id":"","remote_ip":"127.0.0.1","host":"127.0.0.1:1323","method":"GET","uri":"/cves/CVE-2017-5715","user_agent":"curl/7.68.0","status":200,"error":"","latency":55261926,"latency_human":"55.261926ms","bytes_in":0,"bytes_out":674403}
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I used the JSON from this link to run a report in vuls.
- JSON file comment: https://github.com/future-architect/vuls/issues/1295#issuecomment-909119820
- Verification log: https://github.com/future-architect/vuls/issues/1295#issuecomment-909612005

Also, I confirmed that there is no impact on the RDB part.
```console
$ make clean-integration && make build-integration
$ make fetch-rdb
$ make diff-server-rdb
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/future-architect/vuls/issues/1295

