### PR TITLE
fix: remove duplicate cves

### DIFF
--- a/commands/fetchjvn.go
+++ b/commands/fetchjvn.go
@@ -150,5 +150,6 @@ func fetchJvn(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	log.Infof("Finished fetching JVN.")
 	return nil
 }

--- a/commands/fetchnvd.go
+++ b/commands/fetchnvd.go
@@ -153,5 +153,6 @@ func fetchNvd(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	log.Infof("Finished fetching NVD.")
 	return nil
 }

--- a/commands/server.go
+++ b/commands/server.go
@@ -51,11 +51,20 @@ func executeServer(cmd *cobra.Command, args []string) (err error) {
 		return xerrors.New("Failed to Insert CVEs into DB. SchemaVersion is old")
 	}
 
-	var count int
-	if count, err = driver.CountNvd(); err != nil {
+	count := 0
+	nvdCount, err := driver.CountNvd()
+	if err != nil {
 		log.Errorf("Failed to count NVD table: %s", err)
 		return err
 	}
+	count += nvdCount
+
+	jvnCount, err := driver.CountJvn()
+	if err != nil {
+		log.Errorf("Failed to count JVN table: %s", err)
+		return err
+	}
+	count += jvnCount
 
 	if count == 0 {
 		log.Infof("No Vulnerability data found. Run the below command to fetch data from NVD")

--- a/db/db.go
+++ b/db/db.go
@@ -36,6 +36,7 @@ type DB interface {
 	InsertJvn([]models.FeedMeta, map[string][]models.Jvn) error
 	InsertNvd([]models.FeedMeta, map[string][]models.Nvd) error
 	CountNvd() (int, error)
+	CountJvn() (int, error)
 }
 
 // NewDB return DB accessor.

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -369,10 +369,6 @@ func (r *RDBDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]mod
 }
 
 func (r *RDBDriver) deleteAndInsertJvn(conn *gorm.DB, cves []models.Jvn) (err error) {
-	if len(cves) == 0 {
-		return nil
-	}
-
 	tx := conn.Begin()
 
 	defer func() {
@@ -456,10 +452,6 @@ func (r *RDBDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]mod
 }
 
 func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, cves []models.Nvd) (err error) {
-	if len(cves) == 0 {
-		return nil
-	}
-
 	tx := conn.Begin()
 
 	defer func() {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -342,6 +342,16 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	return details, nil
 }
 
+// CountJvn count jvn table
+func (r *RDBDriver) CountJvn() (int, error) {
+	var count int64
+	err := r.conn.Model(&models.Jvn{}).Count(&count).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, err
+	}
+	return int(count), nil
+}
+
 // InsertJvn inserts Cve Information into DB
 func (r *RDBDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]models.Jvn) error {
 	for y, cve := range cves {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -356,7 +356,7 @@ func (r *RDBDriver) CountJvn() (int, error) {
 func (r *RDBDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]models.Jvn) error {
 	for y, cve := range cves {
 		logger.Infof("Inserting fetched CVEs(%s)...", y)
-		if err := r.deleteAndInsertJvn(r.conn, cve); err != nil {
+		if err := r.deleteAndInsertJvn(cve); err != nil {
 			return xerrors.Errorf("Failed to deleteAndInsertJvn. err: %w", err)
 		}
 	}
@@ -368,8 +368,8 @@ func (r *RDBDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]mod
 	return nil
 }
 
-func (r *RDBDriver) deleteAndInsertJvn(conn *gorm.DB, cves []models.Jvn) (err error) {
-	tx := conn.Begin()
+func (r *RDBDriver) deleteAndInsertJvn(cves []models.Jvn) (err error) {
+	tx := r.conn.Begin()
 
 	defer func() {
 		if err != nil {
@@ -439,7 +439,7 @@ func (r *RDBDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]mod
 
 	for y, cve := range cves {
 		logger.Infof("Inserting fetched CVEs(%s)...", y)
-		if err := r.deleteAndInsertNvd(r.conn, cve); err != nil {
+		if err := r.deleteAndInsertNvd(cve); err != nil {
 			return xerrors.Errorf("Failed to deleteAndInsertNvd. err: %w", err)
 		}
 	}
@@ -451,8 +451,8 @@ func (r *RDBDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]mod
 	return nil
 }
 
-func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, cves []models.Nvd) (err error) {
-	tx := conn.Begin()
+func (r *RDBDriver) deleteAndInsertNvd(cves []models.Nvd) (err error) {
+	tx := r.conn.Begin()
 
 	defer func() {
 		if err != nil {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -344,37 +344,25 @@ func (r *RDBDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 
 // InsertJvn inserts Cve Information into DB
 func (r *RDBDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]models.Jvn) error {
-	logger.Infof("Inserting fetched CVEs...")
-	for _, meta := range feedMetas {
-		result := r.conn.Where(&models.FeedMeta{Source: meta.Source, Year: meta.Year}).Take(&meta)
-		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("Failed to select. err: %s", result.Error)
-		}
-
-		if result.RowsAffected == 0 {
-			if err := r.conn.Create(&meta).Error; err != nil {
-				return xerrors.Errorf("Failed to insert. err: %w", err)
-			}
-		}
-
-		if _, ok := cves[meta.Year]; !ok {
-			return xerrors.Errorf("Failed to get cves[%s].", meta.Year)
-		}
-
-		if err := r.deleteAndInsertJvn(r.conn, meta.ID, cves[meta.Year]); err != nil {
+	for y, cve := range cves {
+		logger.Infof("Inserting fetched CVEs(%s)...", y)
+		if err := r.deleteAndInsertJvn(r.conn, cve); err != nil {
 			return xerrors.Errorf("Failed to deleteAndInsertJvn. err: %w", err)
 		}
+	}
 
-		meta.Hash = meta.LatestHash
-		meta.LastModifiedDate = meta.LatestLastModifiedDate
-		if err := r.conn.Save(&meta).Error; err != nil {
-			return xerrors.Errorf("Failed to insert. err: %w", err)
-		}
+	logger.Infof("Updating FeedMetas...")
+	if err := r.upsertFeedMetas(feedMetas); err != nil {
+		return xerrors.Errorf("Failed to upsertFeedMetas. err: %w", err)
 	}
 	return nil
 }
 
-func (r *RDBDriver) deleteAndInsertJvn(conn *gorm.DB, feedMetaID uint, cves []models.Jvn) (err error) {
+func (r *RDBDriver) deleteAndInsertJvn(conn *gorm.DB, cves []models.Jvn) (err error) {
+	if len(cves) == 0 {
+		return nil
+	}
+
 	tx := conn.Begin()
 
 	defer func() {
@@ -387,29 +375,28 @@ func (r *RDBDriver) deleteAndInsertJvn(conn *gorm.DB, feedMetaID uint, cves []mo
 	}()
 
 	// Delete all old records
-	var olds []models.Jvn
-	if err := tx.Where(&models.Jvn{FeedMetaID: feedMetaID}).Find(&olds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-
-	if len(olds) > 0 {
-		logger.Infof("Deleting old CVEs...")
-		bar := pb.StartNew(len(olds))
-		for idx := range chunkSlice(len(olds), r.batchSize) {
-			if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).
-				Select("Cvss2", "Cvss3", "Cpes", "References", "Certs").
-				Delete(olds[idx.From:idx.To]).Error; err != nil {
-				return err
-			}
-			bar.Add(idx.To - idx.From)
-		}
-		bar.Finish()
-	}
-
-	logger.Infof("Inserting new CVEs...")
+	logger.Infof("Deleting old CVEs...")
 	bar := pb.StartNew(len(cves))
 	for _, cve := range cves {
-		cve.FeedMetaID = feedMetaID
+		var old models.Jvn
+		result := tx.Where(&models.Jvn{JvnID: cve.JvnID, CveID: cve.CveID}).Take(&old)
+		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return result.Error
+		}
+		if result.RowsAffected == 1 {
+			if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).
+				Select("Cvss2", "Cvss3", "Cpes", "References", "Certs").
+				Delete(old).Error; err != nil {
+				return err
+			}
+		}
+		bar.Increment()
+	}
+	bar.Finish()
+
+	logger.Infof("Inserting new CVEs...")
+	bar = pb.StartNew(len(cves))
+	for _, cve := range cves {
 		if err := tx.Omit("Cpes").Create(&cve).Error; err != nil {
 			return fmt.Errorf("Failed to insert. err: %s", err)
 		}
@@ -443,37 +430,26 @@ func (r *RDBDriver) CountNvd() (int, error) {
 
 // InsertNvd Cve information from DB.
 func (r *RDBDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]models.Nvd) (err error) {
-	logger.Infof("Inserting fetched CVEs...")
-	for _, meta := range feedMetas {
-		result := r.conn.Where(&models.FeedMeta{Source: meta.Source, Year: meta.Year}).Take(&meta)
-		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("Failed to select. err: %s", result.Error)
-		}
 
-		if result.RowsAffected == 0 {
-			if err := r.conn.Create(&meta).Error; err != nil {
-				return xerrors.Errorf("Failed to insert. err: %w", err)
-			}
-		}
-
-		if _, ok := cves[meta.Year]; !ok {
-			return xerrors.Errorf("Failed to get cves[%s].", meta.Year)
-		}
-
-		if err := r.deleteAndInsertNvd(r.conn, meta.ID, cves[meta.Year]); err != nil {
+	for y, cve := range cves {
+		logger.Infof("Inserting fetched CVEs(%s)...", y)
+		if err := r.deleteAndInsertNvd(r.conn, cve); err != nil {
 			return xerrors.Errorf("Failed to deleteAndInsertNvd. err: %w", err)
 		}
+	}
 
-		meta.Hash = meta.LatestHash
-		meta.LastModifiedDate = meta.LatestLastModifiedDate
-		if err := r.conn.Save(&meta).Error; err != nil {
-			return xerrors.Errorf("Failed to insert. err: %w", err)
-		}
+	logger.Infof("Updating FeedMetas...")
+	if err := r.upsertFeedMetas(feedMetas); err != nil {
+		return xerrors.Errorf("Failed to upsertFeedMetas. err: %w", err)
 	}
 	return nil
 }
 
-func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, feedMetaID uint, cves []models.Nvd) (err error) {
+func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, cves []models.Nvd) (err error) {
+	if len(cves) == 0 {
+		return nil
+	}
+
 	tx := conn.Begin()
 
 	defer func() {
@@ -486,17 +462,17 @@ func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, feedMetaID uint, cves []mo
 	}()
 
 	// Delete all old records
-	var olds []models.Nvd
-	if err := tx.Where(&models.Nvd{FeedMetaID: feedMetaID}).Find(&olds).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-
-	if len(olds) > 0 {
-		logger.Infof("Deleting old CVEs...")
-		bar := pb.StartNew(len(olds))
-		for idx := range chunkSlice(len(olds), r.batchSize) {
+	logger.Infof("Deleting old CVEs...")
+	bar := pb.StartNew(len(cves))
+	for _, cve := range cves {
+		var old models.Nvd
+		result := tx.Where(&models.Nvd{CveID: cve.CveID}).Take(&old)
+		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return result.Error
+		}
+		if result.RowsAffected == 1 {
 			var oldCpes []models.NvdCpe
-			if err := tx.Model(olds[idx.From:idx.To]).Association("Cpes").Find(&oldCpes); err != nil {
+			if err := tx.Model(old).Association("Cpes").Find(&oldCpes); err != nil {
 				return err
 			}
 			if err := tx.Model(&oldCpes).Association("EnvCpes").Clear(); err != nil {
@@ -505,18 +481,17 @@ func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, feedMetaID uint, cves []mo
 
 			if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).
 				Select("Descriptions", "Cvss2", "Cvss3", "Cwes", "Cpes", "References", "Certs").
-				Delete(olds[idx.From:idx.To]).Error; err != nil {
+				Delete(old).Error; err != nil {
 				return err
 			}
-			bar.Add(idx.To - idx.From)
 		}
-		bar.Finish()
+		bar.Increment()
 	}
+	bar.Finish()
 
 	logger.Infof("Inserting new CVEs...")
-	bar := pb.StartNew(len(cves))
+	bar = pb.StartNew(len(cves))
 	for _, cve := range cves {
-		cve.FeedMetaID = feedMetaID
 		if err := tx.Omit("Cpes").Create(&cve).Error; err != nil {
 			return fmt.Errorf("Failed to insert. err: %s", err)
 		}
@@ -535,6 +510,21 @@ func (r *RDBDriver) deleteAndInsertNvd(conn *gorm.DB, feedMetaID uint, cves []mo
 	bar.Finish()
 
 	logger.Infof("Refreshed %d Nvds.", len(cves))
+	return nil
+}
+
+func (r *RDBDriver) upsertFeedMetas(feedMetas []models.FeedMeta) error {
+	for _, meta := range feedMetas {
+		if err := r.conn.Where(&models.FeedMeta{Source: meta.Source, Year: meta.Year}).Take(&meta).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("Failed to select. err: %s", err)
+		}
+
+		meta.Hash = meta.LatestHash
+		meta.LastModifiedDate = meta.LatestLastModifiedDate
+		if err := r.conn.Save(&meta).Error; err != nil {
+			return xerrors.Errorf("Failed to insert. err: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/db/redis.go
+++ b/db/redis.go
@@ -291,6 +291,16 @@ func (r *RedisDriver) GetByCpeURI(uri string) ([]models.CveDetail, error) {
 	return details, nil
 }
 
+// CountJvn count jvn table
+func (r *RedisDriver) CountJvn() (int, error) {
+	ctx := context.Background()
+	var result *redis.StringSliceCmd
+	if result = r.conn.Keys(ctx, jvnKeyPrefix+"CVE*"); result.Err() != nil {
+		return 0, result.Err()
+	}
+	return len(result.Val()), nil
+}
+
 // InsertJvn insert items fetched from JVN.
 func (r *RedisDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]models.Jvn) error {
 	log.Infof("Inserting fetched CVEs...")

--- a/db/redis.go
+++ b/db/redis.go
@@ -310,14 +310,10 @@ func (r *RedisDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]m
 	var err error
 	pipe := r.conn.Pipeline()
 
-	for _, meta := range feedMetas {
-		insertCves, ok := cves[meta.Year]
-		if !ok {
-			return xerrors.Errorf("Failed to get cves[%s].", meta.Year)
-		}
-
-		bar := pb.StartNew(len(insertCves))
-		for _, cve := range insertCves {
+	for y, cs := range cves {
+		log.Infof("Inserting fetched CVEs(%s)...", y)
+		bar := pb.StartNew(len(cs))
+		for _, cve := range cs {
 			cpes := append([]models.JvnCpe{}, cve.Cpes...)
 
 			var jj []byte
@@ -380,17 +376,15 @@ func (r *RedisDriver) InsertJvn(feedMetas []models.FeedMeta, cves map[string][]m
 		}
 		bar.Finish()
 
-		log.Infof("Refreshed %d Jvns.", len(insertCves))
-
-		meta.Hash = meta.LatestHash
-		meta.LastModifiedDate = meta.LatestLastModifiedDate
-		if err := r.upsertFeedHash(meta); err != nil {
-			return fmt.Errorf("Failed to upsertFeedHash. err: %s", err)
-		}
+		log.Infof("Refreshed %d Jvns.", len(cs))
 	}
 
 	if _, err = pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("Failed to exec pipeline. err: %s", err)
+	}
+
+	if err := r.upsertFeedMetas(feedMetas); err != nil {
+		return fmt.Errorf("Failed to upsertFeedMetas. err: %s", err)
 	}
 
 	return nil
@@ -415,14 +409,10 @@ func (r *RedisDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]m
 	var err error
 	pipe := r.conn.Pipeline()
 
-	for _, meta := range feedMetas {
-		insertCves, ok := cves[meta.Year]
-		if !ok {
-			return xerrors.Errorf("Failed to get cves[%s].", meta.Year)
-		}
-
-		bar := pb.StartNew(len(insertCves))
-		for _, cve := range insertCves {
+	for y, cs := range cves {
+		log.Infof("Inserting fetched CVEs(%s)...", y)
+		bar := pb.StartNew(len(cs))
+		for _, cve := range cs {
 			cpes := append([]models.NvdCpe{}, cve.Cpes...)
 
 			var jn []byte
@@ -484,53 +474,57 @@ func (r *RedisDriver) InsertNvd(feedMetas []models.FeedMeta, cves map[string][]m
 		}
 		bar.Finish()
 
-		log.Infof("Refreshed %d Nvds.", len(insertCves))
-
-		meta.Hash = meta.LatestHash
-		meta.LastModifiedDate = meta.LatestLastModifiedDate
-		if err := r.upsertFeedHash(meta); err != nil {
-			return fmt.Errorf("Failed to upsertFeedHash. err: %s", err)
-		}
+		log.Infof("Refreshed %d Nvds.", len(cs))
 	}
 
 	if _, err = pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("Failed to exec pipeline. err: %s", err)
 	}
 
+	if err := r.upsertFeedMetas(feedMetas); err != nil {
+		return fmt.Errorf("Failed to upsertFeedMetas. err: %s", err)
+	}
+
 	return nil
 }
 
-func (r *RedisDriver) upsertFeedHash(m models.FeedMeta) error {
+func (r *RedisDriver) upsertFeedMetas(feedMetas []models.FeedMeta) error {
 	ctx := context.Background()
 	expire := viper.GetUint("expire")
-	jn, err := json.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("Failed to marshal json. err: %s", err)
-	}
-
-	var key string
-	switch m.Source {
-	case models.NvdType:
-		key = feedKeyPrefix + "NVD"
-	case models.JvnType:
-		key = feedKeyPrefix + "JVN"
-	default:
-		return xerrors.New("Failed to determine Source by URL.")
-	}
-
 	pipe := r.conn.Pipeline()
-	if result := pipe.HSet(ctx, key, m.URL, jn); result.Err() != nil {
-		return fmt.Errorf("Failed to HSet META. err: %s", result.Err())
-	}
-	if expire > 0 {
-		if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
-			return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+
+	for _, meta := range feedMetas {
+		meta.Hash = meta.LatestHash
+		meta.LastModifiedDate = meta.LatestLastModifiedDate
+		jn, err := json.Marshal(meta)
+		if err != nil {
+			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
-	} else {
-		if err := pipe.Persist(ctx, key).Err(); err != nil {
-			return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+
+		var key string
+		switch meta.Source {
+		case models.NvdType:
+			key = feedKeyPrefix + "NVD"
+		case models.JvnType:
+			key = feedKeyPrefix + "JVN"
+		default:
+			return xerrors.New("Failed to determine Source by URL.")
+		}
+
+		if err := pipe.HSet(ctx, key, meta.URL, jn).Err(); err != nil {
+			return fmt.Errorf("Failed to HSet META. err: %s", err)
+		}
+		if expire > 0 {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
+			}
+		} else {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 	}
+
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("Failed to exec pipeline. err: %s", err)
 	}

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -183,6 +183,7 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Jvn, error) {
 		return nil, err
 	}
 
+	// {"year", "recent" or "modified": { "JVNID#CVE-ID":Jvn{} } }
 	uniqCves := map[string]map[string]models.Jvn{}
 	for y, item := range items {
 		cs, err := convert(item)
@@ -192,11 +193,13 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Jvn, error) {
 		uniqCves[y] = cs
 	}
 
+	// The recent and modified contain duplicate CVE-ID. Select the most recent one.
 	distributeCvesByYear(uniqCves, uniqCves["recent"])
 	distributeCvesByYear(uniqCves, uniqCves["modified"])
 	delete(uniqCves, "recent")
 	delete(uniqCves, "modified")
 
+	// {"year": []Jvn{} }
 	cves := map[string][]models.Jvn{}
 	for year, cs := range uniqCves {
 		cveSet := []models.Jvn{}

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -598,16 +598,16 @@ func getCveIDs(item Item) []string {
 }
 
 func distributeCvesByYear(uniqCves map[string]map[string]models.Jvn, cves map[string]models.Jvn) {
-	for _, cve := range cves {
-		y := strings.Split(cve.CveID, "-")[1]
+	for uniqJVNID, cve := range cves {
+		y := strings.Split(cve.JvnID, "-")[1]
 		if _, ok := uniqCves[y]; !ok {
 			uniqCves[y] = map[string]models.Jvn{}
 		}
-		if destCve, ok := uniqCves[y][cve.CveID]; !ok {
-			uniqCves[y][cve.CveID] = cve
+		if destCve, ok := uniqCves[y][uniqJVNID]; !ok {
+			uniqCves[y][uniqJVNID] = cve
 		} else {
 			if cve.LastModifiedDate.After(destCve.LastModifiedDate) {
-				uniqCves[y][cve.CveID] = cve
+				uniqCves[y][uniqJVNID] = cve
 			}
 		}
 	}

--- a/fetcher/jvn/jvn.go
+++ b/fetcher/jvn/jvn.go
@@ -183,13 +183,27 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Jvn, error) {
 		return nil, err
 	}
 
-	cves := map[string][]models.Jvn{}
+	uniqCves := map[string]map[string]models.Jvn{}
 	for y, item := range items {
 		cs, err := convert(item)
 		if err != nil {
 			return nil, err
 		}
-		cves[y] = cs
+		uniqCves[y] = cs
+	}
+
+	distributeCvesByYear(uniqCves, uniqCves["recent"])
+	distributeCvesByYear(uniqCves, uniqCves["modified"])
+	delete(uniqCves, "recent")
+	delete(uniqCves, "modified")
+
+	cves := map[string][]models.Jvn{}
+	for year, cs := range uniqCves {
+		cveSet := []models.Jvn{}
+		for _, c := range cs {
+			cveSet = append(cveSet, c)
+		}
+		cves[year] = cveSet
 	}
 
 	return cves, nil
@@ -232,7 +246,7 @@ func fetch(metas []models.FeedMeta) (map[string][]Item, error) {
 	return fetchedItems, nil
 }
 
-func convert(items []Item) (cves []models.Jvn, err error) {
+func convert(items []Item) (map[string]models.Jvn, error) {
 	reqChan := make(chan Item, len(items))
 	resChan := make(chan []models.Jvn, len(items))
 	errChan := make(chan error)
@@ -260,12 +274,16 @@ func convert(items []Item) (cves []models.Jvn, err error) {
 		}
 	}
 
+	cves := map[string]models.Jvn{}
 	errs := []error{}
 	timeout := time.After(10 * 60 * time.Second)
 	for range items {
 		select {
 		case res := <-resChan:
-			cves = append(cves, res...)
+			for _, cve := range res {
+				uniqJVNID := fmt.Sprintf("%s#%s", cve.JvnID, cve.CveID)
+				cves[uniqJVNID] = cve
+			}
 		case err := <-errChan:
 			errs = append(errs, err)
 		case <-timeout:
@@ -577,4 +595,20 @@ func getCveIDs(item Item) []string {
 		cveIDs = append(cveIDs, cveID)
 	}
 	return cveIDs
+}
+
+func distributeCvesByYear(uniqCves map[string]map[string]models.Jvn, cves map[string]models.Jvn) {
+	for _, cve := range cves {
+		y := strings.Split(cve.CveID, "-")[1]
+		if _, ok := uniqCves[y]; !ok {
+			uniqCves[y] = map[string]models.Jvn{}
+		}
+		if destCve, ok := uniqCves[y][cve.CveID]; !ok {
+			uniqCves[y][cve.CveID] = cve
+		} else {
+			if cve.LastModifiedDate.After(destCve.LastModifiedDate) {
+				uniqCves[y][cve.CveID] = cve
+			}
+		}
+	}
 }

--- a/fetcher/jvn/jvn_test.go
+++ b/fetcher/jvn/jvn_test.go
@@ -3,20 +3,28 @@ package jvn
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/kotakanbe/go-cve-dictionary/models"
 )
 
 func TestDistributeCvesByYear(t *testing.T) {
+	type args struct {
+		uniqMap map[string]map[string]models.Jvn
+		cves    map[string]models.Jvn
+	}
 	var tests = []struct {
-		in       map[string]models.Jvn
+		in       args
 		expected map[string]map[string]models.Jvn
 	}{
 		{
-			in: map[string]models.Jvn{
-				"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001"},
-				"JVNDB-2021-0001#CVE-2020-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2020-0001"},
-				"JVNDB-2020-0001#CVE-2020-0001": {JvnID: "JVNDB-2020-0001", CveID: "CVE-2020-0001"},
+			in: args{
+				uniqMap: map[string]map[string]models.Jvn{},
+				cves: map[string]models.Jvn{
+					"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001"},
+					"JVNDB-2021-0001#CVE-2020-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2020-0001"},
+					"JVNDB-2020-0001#CVE-2020-0001": {JvnID: "JVNDB-2020-0001", CveID: "CVE-2020-0001"},
+				},
 			},
 			expected: map[string]map[string]models.Jvn{
 				"2020": {
@@ -28,13 +36,29 @@ func TestDistributeCvesByYear(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: args{
+				uniqMap: map[string]map[string]models.Jvn{
+					"2021": {
+						"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 3, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+				cves: map[string]models.Jvn{
+					"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expected: map[string]map[string]models.Jvn{
+				"2021": {
+					"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
-		got := map[string]map[string]models.Jvn{}
-		distributeCvesByYear(got, tt.in)
-		if !reflect.DeepEqual(got, tt.expected) {
-			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, got)
+		distributeCvesByYear(tt.in.uniqMap, tt.in.cves)
+		if !reflect.DeepEqual(tt.in.uniqMap, tt.expected) {
+			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, tt.in.uniqMap)
 		}
 	}
 }

--- a/fetcher/jvn/jvn_test.go
+++ b/fetcher/jvn/jvn_test.go
@@ -1,0 +1,40 @@
+package jvn
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kotakanbe/go-cve-dictionary/models"
+)
+
+func TestDistributeCvesByYear(t *testing.T) {
+	var tests = []struct {
+		in       map[string]models.Jvn
+		expected map[string]map[string]models.Jvn
+	}{
+		{
+			in: map[string]models.Jvn{
+				"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001"},
+				"JVNDB-2021-0001#CVE-2020-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2020-0001"},
+				"JVNDB-2020-0001#CVE-2020-0001": {JvnID: "JVNDB-2020-0001", CveID: "CVE-2020-0001"},
+			},
+			expected: map[string]map[string]models.Jvn{
+				"2020": {
+					"JVNDB-2020-0001#CVE-2020-0001": {JvnID: "JVNDB-2020-0001", CveID: "CVE-2020-0001"},
+				},
+				"2021": {
+					"JVNDB-2021-0001#CVE-2021-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2021-0001"},
+					"JVNDB-2021-0001#CVE-2020-0001": {JvnID: "JVNDB-2021-0001", CveID: "CVE-2020-0001"},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		got := map[string]map[string]models.Jvn{}
+		distributeCvesByYear(got, tt.in)
+		if !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, got)
+		}
+	}
+}

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -24,6 +24,7 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Nvd, error) {
 		return nil, err
 	}
 
+	// {"year", "recent" or "modified": { "CVE-ID": Nvd{} } }
 	uniqCves := map[string]map[string]models.Nvd{}
 	for y, item := range items {
 		cs, err := convert(item)
@@ -33,6 +34,7 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Nvd, error) {
 		uniqCves[y] = cs
 	}
 
+	// The recent and modified contain duplicate CVE-ID. Select the most recent one.
 	distributeCvesByYear(uniqCves, uniqCves["recent"])
 	distributeCvesByYear(uniqCves, uniqCves["modified"])
 	delete(uniqCves, "recent")

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -24,13 +24,27 @@ func FetchConvert(metas []models.FeedMeta) (map[string][]models.Nvd, error) {
 		return nil, err
 	}
 
-	cves := map[string][]models.Nvd{}
+	uniqCves := map[string]map[string]models.Nvd{}
 	for y, item := range items {
 		cs, err := convert(item)
 		if err != nil {
 			return nil, err
 		}
-		cves[y] = cs
+		uniqCves[y] = cs
+	}
+
+	distributeCvesByYear(uniqCves, uniqCves["recent"])
+	distributeCvesByYear(uniqCves, uniqCves["modified"])
+	delete(uniqCves, "recent")
+	delete(uniqCves, "modified")
+
+	cves := map[string][]models.Nvd{}
+	for year, cs := range uniqCves {
+		cveSet := []models.Nvd{}
+		for _, c := range cs {
+			cveSet = append(cveSet, c)
+		}
+		cves[year] = cveSet
 	}
 
 	return cves, nil
@@ -90,7 +104,7 @@ func fetch(metas []models.FeedMeta) (map[string][]CveItem, error) {
 	return items, nil
 }
 
-func convert(items []CveItem) (cves []models.Nvd, err error) {
+func convert(items []CveItem) (map[string]models.Nvd, error) {
 	reqChan := make(chan CveItem, len(items))
 	resChan := make(chan *models.Nvd, len(items))
 	errChan := make(chan error, len(items))
@@ -118,12 +132,13 @@ func convert(items []CveItem) (cves []models.Nvd, err error) {
 		}
 	}
 
+	cves := map[string]models.Nvd{}
 	errs := []error{}
 	timeout := time.After(10 * 60 * time.Second)
 	for range items {
 		select {
 		case res := <-resChan:
-			cves = append(cves, *res)
+			cves[res.CveID] = *res
 		case err := <-errChan:
 			errs = append(errs, err)
 		case <-timeout:
@@ -134,6 +149,22 @@ func convert(items []CveItem) (cves []models.Nvd, err error) {
 		return nil, fmt.Errorf("%s", errs)
 	}
 	return cves, nil
+}
+
+func distributeCvesByYear(uniqCves map[string]map[string]models.Nvd, cves map[string]models.Nvd) {
+	for _, cve := range cves {
+		y := strings.Split(cve.CveID, "-")[1]
+		if _, ok := uniqCves[y]; !ok {
+			uniqCves[y] = map[string]models.Nvd{}
+		}
+		if destCve, ok := uniqCves[y][cve.CveID]; !ok {
+			uniqCves[y][cve.CveID] = cve
+		} else {
+			if cve.LastModifiedDate.After(destCve.LastModifiedDate) {
+				uniqCves[y][cve.CveID] = cve
+			}
+		}
+	}
 }
 
 // Nvd is a struct of NVD JSON

--- a/fetcher/nvd/nvd.go
+++ b/fetcher/nvd/nvd.go
@@ -151,22 +151,6 @@ func convert(items []CveItem) (map[string]models.Nvd, error) {
 	return cves, nil
 }
 
-func distributeCvesByYear(uniqCves map[string]map[string]models.Nvd, cves map[string]models.Nvd) {
-	for _, cve := range cves {
-		y := strings.Split(cve.CveID, "-")[1]
-		if _, ok := uniqCves[y]; !ok {
-			uniqCves[y] = map[string]models.Nvd{}
-		}
-		if destCve, ok := uniqCves[y][cve.CveID]; !ok {
-			uniqCves[y][cve.CveID] = cve
-		} else {
-			if cve.LastModifiedDate.After(destCve.LastModifiedDate) {
-				uniqCves[y][cve.CveID] = cve
-			}
-		}
-	}
-}
-
 // Nvd is a struct of NVD JSON
 // https://scap.nist.gov/schema/nvd/feed/1.1/nvd_cve_feed_json_1.1.schema
 type Nvd struct {
@@ -508,4 +492,20 @@ func parseNvdTime(strtime string) (t time.Time, err error) {
 			strtime, err)
 	}
 	return
+}
+
+func distributeCvesByYear(uniqCves map[string]map[string]models.Nvd, cves map[string]models.Nvd) {
+	for _, cve := range cves {
+		y := strings.Split(cve.CveID, "-")[1]
+		if _, ok := uniqCves[y]; !ok {
+			uniqCves[y] = map[string]models.Nvd{}
+		}
+		if destCve, ok := uniqCves[y][cve.CveID]; !ok {
+			uniqCves[y][cve.CveID] = cve
+		} else {
+			if cve.LastModifiedDate.After(destCve.LastModifiedDate) {
+				uniqCves[y][cve.CveID] = cve
+			}
+		}
+	}
 }

--- a/fetcher/nvd/nvd_test.go
+++ b/fetcher/nvd/nvd_test.go
@@ -1,0 +1,38 @@
+package nvd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kotakanbe/go-cve-dictionary/models"
+)
+
+func TestDistributeCvesByYear(t *testing.T) {
+	var tests = []struct {
+		in       map[string]models.Nvd
+		expected map[string]map[string]models.Nvd
+	}{
+		{
+			in: map[string]models.Nvd{
+				"CVE-2021-0001": {CveID: "CVE-2021-0001"},
+				"CVE-2020-0001": {CveID: "CVE-2020-0001"},
+			},
+			expected: map[string]map[string]models.Nvd{
+				"2020": {
+					"CVE-2020-0001": {CveID: "CVE-2020-0001"},
+				},
+				"2021": {
+					"CVE-2021-0001": {CveID: "CVE-2021-0001"},
+				},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		got := map[string]map[string]models.Nvd{}
+		distributeCvesByYear(got, tt.in)
+		if !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, got)
+		}
+	}
+}

--- a/fetcher/nvd/nvd_test.go
+++ b/fetcher/nvd/nvd_test.go
@@ -3,19 +3,27 @@ package nvd
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/kotakanbe/go-cve-dictionary/models"
 )
 
 func TestDistributeCvesByYear(t *testing.T) {
+	type args struct {
+		uniqMap map[string]map[string]models.Nvd
+		cves    map[string]models.Nvd
+	}
 	var tests = []struct {
-		in       map[string]models.Nvd
+		in       args
 		expected map[string]map[string]models.Nvd
 	}{
 		{
-			in: map[string]models.Nvd{
-				"CVE-2021-0001": {CveID: "CVE-2021-0001"},
-				"CVE-2020-0001": {CveID: "CVE-2020-0001"},
+			in: args{
+				uniqMap: map[string]map[string]models.Nvd{},
+				cves: map[string]models.Nvd{
+					"CVE-2021-0001": {CveID: "CVE-2021-0001"},
+					"CVE-2020-0001": {CveID: "CVE-2020-0001"},
+				},
 			},
 			expected: map[string]map[string]models.Nvd{
 				"2020": {
@@ -26,13 +34,29 @@ func TestDistributeCvesByYear(t *testing.T) {
 				},
 			},
 		},
+		{
+			in: args{
+				uniqMap: map[string]map[string]models.Nvd{
+					"2021": {
+						"CVE-2021-0001": {CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 3, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+				cves: map[string]models.Nvd{
+					"CVE-2021-0001": {CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expected: map[string]map[string]models.Nvd{
+				"2021": {
+					"CVE-2021-0001": {CveID: "CVE-2021-0001", LastModifiedDate: time.Date(2021, time.September, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {
-		got := map[string]map[string]models.Nvd{}
-		distributeCvesByYear(got, tt.in)
-		if !reflect.DeepEqual(got, tt.expected) {
-			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, got)
+		distributeCvesByYear(tt.in.uniqMap, tt.in.cves)
+		if !reflect.DeepEqual(tt.in.uniqMap, tt.expected) {
+			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.expected, tt.in.uniqMap)
 		}
 	}
 }

--- a/fetcher/nvd/util.go
+++ b/fetcher/nvd/util.go
@@ -77,7 +77,7 @@ func nvdFeedURLToYear(url string) (year int, err error) {
 func FetchLatestFeedMeta(driver db.DB, years []int) (metas []models.FeedMeta, err error) {
 	reqs := []fetcher.FetchRequest{}
 	for _, year := range years {
-		urls := MakeNvdMetaURLs(year)
+		urls := makeNvdMetaURLs(year)
 		for _, url := range urls {
 			reqs = append(reqs, fetcher.FetchRequest{
 				Year: year,
@@ -122,8 +122,8 @@ func FetchLatestFeedMeta(driver db.DB, years []int) (metas []models.FeedMeta, er
 	return
 }
 
-// MakeNvdMetaURLs returns a URL of NVD Feed
-func MakeNvdMetaURLs(year int) (url []string) {
+// makeNvdMetaURLs returns a URL of NVD Feed
+func makeNvdMetaURLs(year int) (url []string) {
 	formatTemplate := "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%s.meta"
 	if year == c.Latest {
 		for _, name := range []string{"modified", "recent"} {

--- a/fetcher/nvd/util_test.go
+++ b/fetcher/nvd/util_test.go
@@ -56,7 +56,7 @@ func TestMakeNvdMetaURL(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		url := MakeNvdMetaURLs(tt.year)
+		url := makeNvdMetaURLs(tt.year)
 		if !reflect.DeepEqual(url, tt.url) {
 			t.Errorf("[%d] expected: %v\n  actual: %v\n", i, tt.url, url)
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -265,7 +265,6 @@ type Cert struct {
 // https://scap.nist.gov/schema/nvd/feed/0.1/nvd_cve_feed_json_0.1_beta.schema
 type Nvd struct {
 	ID               int64  `json:"-"`
-	FeedMetaID       uint   `json:"-"`
 	CveID            string `gorm:"index:idx_nvds_cveid;type:varchar(255)"`
 	Descriptions     []NvdDescription
 	Cvss2            NvdCvss2Extra
@@ -352,7 +351,6 @@ type NvdCert struct {
 // Jvn is a model of JVN
 type Jvn struct {
 	ID               int64  `json:"-"`
-	FeedMetaID       uint   `json:"-"`
 	CveID            string `gorm:"index:idx_jvns_cveid;type:varchar(255)"`
 	Title            string `gorm:"type:varchar(255)"`
 	Summary          string `gorm:"type:text"`


### PR DESCRIPTION
# What did you implement:
CVEs of "recent" and "modified" that were always brought at fetch time were duplicated with CVEs of years.
In the case of RDB, multiple CVEs were inserted, and multiple identical ones appeared in the response. Also, in the case of Redis, the data was overwritten, and old data may have appeared in the response.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## NVD
```console
$ go-cve-dictionary.old fetch nvd --years 2021 --dbpath ./cve.old.sqlite
$ go-cve-dictionary.new fetch nvd --years 2021 --dbpath ./cve.new.sqlite

$ go-cve-dictionary.old server --dbpath ./cve.old.sqlite --port 1325
$ go-cve-dictionary.new server --dbpath ./cve.new.sqlite --port 1326

// upstream/master
$ curl http://127.0.0.1:1326/cves/CVE-2020-20349 | jq | grep "CveID"
  "CveID": "CVE-2020-20349",
      "CveID": "CVE-2020-20349",
      "CveID": "CVE-2020-20349",

// PR
$ curl http://127.0.0.1:1326/cves/CVE-2020-20349 | jq | grep "CveID"
  "CveID": "CVE-2020-20349",
      "CveID": "CVE-2020-20349",
```

## JVN
```console
$ go-cve-dictionary.old fetch jvn --years 2021 --dbpath ./cve.old.sqlite
$ go-cve-dictionary.new fetch jvn --years 2021 --dbpath ./cve.new.sqlite

$ go-cve-dictionary.old server --dbpath ./cve.old.sqlite --port 1325
$ go-cve-dictionary.new server --dbpath ./cve.new.sqlite --port 1326

// upstream/master
$ curl http://127.0.0.1:1326/cves/CVE-2020-35838 | jq | grep "ID"
  "CveID": "CVE-2020-35838",
      "CveID": "CVE-2020-35838",
      "JvnID": "JVNDB-2020-014893",
      "CveID": "CVE-2020-35838",
      "JvnID": "JVNDB-2020-014893",

// PR
$ curl http://127.0.0.1:1326/cves/CVE-2020-35838 | jq | grep "ID"
  "CveID": "CVE-2020-35838",
      "CveID": "CVE-2020-35838",
      "JvnID": "JVNDB-2020-014893",
```

## Integration
```console
$ make clean-integration && make build-integration
$ make fetch-rdb && make fetch-redis
$ make diff-server-rdb-redis
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

