### PR TITLE
fix(cpescan): bug in NvdVendorProductMatch

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -115,6 +115,8 @@ diff-cpes:
 	@ python integration/diff_server_mode.py cpe_ids --sample_rate 0.01
 
 diff-server-rdb:
+	- pkill -KILL go-cve.old
+	- pkill -KILL go-cve.new
 	integration/go-cve.old server --dbpath=$(PWD)/integration/cve.old.sqlite3 --port 1325 > /dev/null 2>&1 & 
 	integration/go-cve.new server --dbpath=$(PWD)/integration/cve.new.sqlite3 --port 1326 > /dev/null 2>&1 &
 	make diff-cveid
@@ -123,6 +125,8 @@ diff-server-rdb:
 	pkill go-cve.new
 
 diff-server-redis:
+	- pkill -KILL go-cve.old
+	- pkill -KILL go-cve.new
 	integration/go-cve.old server --dbtype redis --dbpath "redis://127.0.0.1:6379/0" --port 1325 > /dev/null 2>&1 & 
 	integration/go-cve.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 & 
 	make diff-cveid
@@ -131,6 +135,8 @@ diff-server-redis:
 	pkill go-cve.new
 
 diff-server-rdb-redis:
+	- pkill -KILL go-cve.old
+	- pkill -KILL go-cve.new
 	integration/go-cve.new server --dbpath=$(PWD)/integration/cve.new.sqlite3 --port 1325 > /dev/null 2>&1 & 
 	integration/go-cve.new server --dbtype redis --dbpath "redis://127.0.0.1:6380/0" --port 1326 > /dev/null 2>&1 & 
 	make diff-cveid

--- a/db/db.go
+++ b/db/db.go
@@ -200,11 +200,6 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 		return false, false, false, nil
 	}
 
-	if matching.IsEqual(specified, cpeInNvdWfn) {
-		log.Debugf("%s equals %s", specified.String(), cpeInNvd.URI)
-		return true, false, false, nil
-	}
-
 	specifiedVer := fmt.Sprintf("%s", specified.Get(common.AttributeVersion))
 	switch specifiedVer {
 	case "NA", "ANY":
@@ -212,6 +207,11 @@ func match(specifiedURI string, cpeInNvd models.CpeBase) (isExactVerMatch, isRou
 			return false, false, false, err
 		}
 		return false, false, isSuperORSubset(cpeInNvdWfn, specified), nil
+	}
+
+	if matching.IsEqual(specified, cpeInNvdWfn) {
+		log.Debugf("%s equals %s", specified.String(), cpeInNvd.URI)
+		return true, false, false, nil
 	}
 
 	ok, err := matchSemver(specifiedVer, cpeInNvd)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -491,6 +491,7 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "NvdExactVersionMatch",
 			args: args{
 				uri: "cpe:/o:vendor:product:1.0.0",
 				cve: &models.CveDetail{
@@ -530,7 +531,7 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 			},
 		},
 		{
-			name: "",
+			name: "NvdVendorProductMatch",
 			args: args{
 				uri: "cpe:/o:vendor:product",
 				cve: &models.CveDetail{
@@ -562,6 +563,32 @@ func Test_filterCveDetailByCpeURI1(t *testing.T) {
 						Cpes: []models.NvdCpe{
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.0"}},
 							{CpeBase: models.CpeBase{URI: "cpe:/o:vendor:product:1.0.1"}},
+						},
+						DetectionMethod: models.NvdVendorProductMatch,
+					},
+				},
+				Jvns: []models.Jvn{},
+			},
+		},
+		{
+			name: "NvdVendorProductMatch",
+			args: args{
+				uri: "cpe:/a:vendor:product",
+				cve: &models.CveDetail{
+					Nvds: []models.Nvd{
+						{
+							Cpes: []models.NvdCpe{
+								{CpeBase: models.CpeBase{URI: "cpe:/a:vendor:product", VersionEndExcluding: "1.0.0"}},
+							},
+						},
+					},
+				},
+			},
+			expected: &models.CveDetail{
+				Nvds: []models.Nvd{
+					{
+						Cpes: []models.NvdCpe{
+							{CpeBase: models.CpeBase{URI: "cpe:/a:vendor:product", VersionEndExcluding: "1.0.0"}},
 						},
 						DetectionMethod: models.NvdVendorProductMatch,
 					},

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -83,6 +84,10 @@ func getCveByCpeName(driver db.DB) echo.HandlerFunc {
 			log.Errorf("%s", err)
 			return err
 		}
+
+		sort.Slice(cveDetails, func(i, j int) bool {
+			return cveDetails[i].CveID < cveDetails[j].CveID
+		})
 		return c.JSON(http.StatusOK, &cveDetails)
 	}
 }


### PR DESCRIPTION
# What did you implement:

When scanning without specifying the version of the CPE, the detection method should become NvdVendorProductMatch.
But there was a bug that if the Affected version of NVD is specified in the range, it became NvdExactVersionMatch.

- config.toml

```
[servers.webmin]
    type = "pseudo"
     cpeNames = ["cpe:/a:webmin:webmin"]
```

- report

```
./vuls report --format-full-text | grep NvdExact
[Oct 12 06:05:33]  INFO [localhost] vuls-v0.18.0-build-20211012_045947_aac5ef1
[Oct 12 06:05:33]  INFO [localhost] Validating config...
[Oct 12 06:05:33]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker/cve.sqlite3
[Oct 12 06:05:33]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/ubuntu/go/src/github.com/future-architect/vuls/oval.sqlite3
[Oct 12 06:05:33]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/ubuntu/go/src/github.com/future-architect/vuls/gost.sqlite3
[Oct 12 06:05:33]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/ubuntu/go/src/github.com/future-architect/vuls/go-exploitdb.sqlite3
[Oct 12 06:05:33]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/ubuntu/go/src/github.com/future-architect/vuls/go-msfdb.sqlite3
[Oct 12 06:05:33]  INFO [localhost] Loaded: /home/ubuntu/go/src/github.com/future-architect/vuls/results/2021-10-12T05:09:07+09:00
[Oct 12 06:05:33]  INFO [localhost] No need to refresh
| Confidence    | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                                          |
| Confidence    | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                                |
| Confidence     | 100 / NvdExactVersionMatch                                                                     |
| Confidence     | 100 / NvdExactVersionMatch                                                                     |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence    | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence    | 100 / NvdExactVersionMatch                                                       |
| Confidence    | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
| Confidence     | 100 / NvdExactVersionMatch                                                       |
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

make test

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
