### PR TITLE
fix(fetcher/euvd): add normalizeDateYear

### DIFF
--- a/fetcher/euvd/euvd.go
+++ b/fetcher/euvd/euvd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -78,7 +79,7 @@ func convert(a advisory) (models.Euvd, error) {
 		if a.DatePublished == "" {
 			return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC), nil
 		}
-		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, a.DatePublished)
+		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, normalizeDateYear(a.DatePublished))
 		if err != nil {
 			return time.Time{}, xerrors.Errorf("Failed to parse Time. err: %w", err)
 		}
@@ -91,7 +92,7 @@ func convert(a advisory) (models.Euvd, error) {
 		if a.DateUpdated == "" {
 			return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC), nil
 		}
-		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, a.DateUpdated)
+		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, normalizeDateYear(a.DateUpdated))
 		if err != nil {
 			return time.Time{}, xerrors.Errorf("Failed to parse Time. err: %w", err)
 		}
@@ -104,7 +105,7 @@ func convert(a advisory) (models.Euvd, error) {
 		if a.ExploitedSince == "" {
 			return nil, nil
 		}
-		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, a.ExploitedSince)
+		t, err := fetcher.ParseTime([]string{"Jan 2, 2006, 3:04:05 PM"}, normalizeDateYear(a.ExploitedSince))
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to parse Time. err: %w", err)
 		}
@@ -152,4 +153,23 @@ func convert(a advisory) (models.Euvd, error) {
 		EPSS:           a.EPSS,
 		ExploitedSince: exploited,
 	}, nil
+}
+
+func normalizeDateYear(value string) string {
+	parts := strings.Split(value, ", ")
+	if len(parts) != 3 {
+		return value
+	}
+
+	year, err := strconv.Atoi(parts[1])
+	if err != nil || year < 0 {
+		return value
+	}
+	switch len(parts[1]) {
+	case 1:
+		parts[1] = strconv.Itoa(year + 2000)
+		return strings.Join(parts, ", ")
+	default:
+		return value
+	}
 }

--- a/fetcher/euvd/euvd_test.go
+++ b/fetcher/euvd/euvd_test.go
@@ -115,6 +115,31 @@ func Test_convert(t *testing.T) {
 				ExploitedSince: func() *time.Time { t := time.Date(2025, 11, 19, 00, 0, 0, 0, time.UTC); return &t }(),
 			},
 		},
+		{
+			name: "single digit year in date fields (+2000)",
+			args: args{
+				a: advisory{
+					ID:            "EUVD-2024-0027",
+					EnisaUUID:     "99fb1811-b078-3d99-aa18-0f6a87b6a1cf",
+					Description:   "Malicious package. Exfiltrated secrets to a target server.",
+					DatePublished: "Jan 1, 1, 2:00:00 AM",
+					DateUpdated:   "Jan 1, 1, 2:00:00 AM",
+					Aliases:       "PYSEC-2024-55\n",
+				},
+			},
+			want: models.Euvd{
+				EuvdID:        "EUVD-2024-0027",
+				EnisaUUID:     "99fb1811-b078-3d99-aa18-0f6a87b6a1cf",
+				Description:   "Malicious package. Exfiltrated secrets to a target server.",
+				DatePublished: time.Date(2001, time.January, 1, 2, 0, 0, 0, time.UTC),
+				DateUpdated:   time.Date(2001, time.January, 1, 2, 0, 0, 0, time.UTC),
+				Aliases: []models.EuvdAlias{
+					{
+						Alias: "PYSEC-2024-55",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes https://github.com/vulsio/go-cve-dictionary/actions/runs/22509757997/job/65216323095#step:9:10

The DataPublished/DataUpdated for EUVD-2024-0027 has a Year part of `1`.
Golang's time.Parse cannot parse a string with a single digit for the year part.
Also, when checking the web page, it shows 2001.
Therefore, we will add 2000 to go-cve-dictionary to make it a valid year.

<img width="1009" height="625" alt="image" src="https://github.com/user-attachments/assets/1448824a-97fc-431d-8043-49576d8adab9" />
https://euvd.enisa.europa.eu/vulnerability/EUVD-2024-0027

```console
$ curl -s -X GET "https://euvdservices.enisa.europa.eu/api/enisaid?id=EUVD-2024-0027" | jq
{
  "id": "EUVD-2024-0027",
  "enisaUuid": "99fb1811-b078-3d99-aa18-0f6a87b6a1cf",
  "description": "Malicious package. Exfiltrated secrets to a target server.",
  "datePublished": "Jan 1, 1, 2:00:00 AM",
  "dateUpdated": "Jan 1, 1, 2:00:00 AM",
  "baseScore": -1,
  "aliases": "PYSEC-2024-55\n",
  "epss": 0,
  "enisaIdProduct": [],
  "enisaIdVendor": [],
  "enisaIdVulnerability": [],
  "enisaIdAdvisory": []
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ go-cve-dictionary fetch euvd
INFO[03-02|16:01:31] Inserting EUVD into DB (sqlite3). 
INFO[03-02|16:01:31] Deleting EUVD tables... 
[========>           ] 589219 files processed. (5791 p/s)                                                                                                                                                          
INFO[03-02|16:03:13] Finished fetching EUVD.

$ sqlite3 cve.sqlite3 'SELECT * FROM euvds WHERE euvd_id == "EUVD-2024-0027"'
317957|EUVD-2024-0027|99fb1811-b078-3d99-aa18-0f6a87b6a1cf|Malicious package. Exfiltrated secrets to a target server.|2001-01-01 02:00:00+00:00|2001-01-01 02:00:00+00:00|-1.0||||0.0|
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

