### PR TITLE
feat(fetcher/cisco): ingest CVSS v3 metrics from CVRF

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -23,7 +23,11 @@ func TestRDBDriver_InsertCiscoCVSSv3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer driver.CloseDB()
+	t.Cleanup(func() {
+		if err := driver.CloseDB(); err != nil {
+			t.Errorf("Failed to close DB. err: %s", err)
+		}
+	})
 
 	if err := driver.InsertCisco(func(yield func(models.Cisco, error) bool) {
 		yield(models.Cisco{

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -2,8 +2,11 @@ package db
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/spf13/viper"
 
 	"github.com/vulsio/go-cve-dictionary/models"
 )
@@ -11,6 +14,68 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	os.Exit(code)
+}
+
+func TestRDBDriver_InsertCiscoCVSSv3(t *testing.T) {
+	viper.Set("batch-size", 100)
+
+	driver, err := NewDB(dialectSqlite3, filepath.Join(t.TempDir(), "cve.sqlite3"), false, Option{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer driver.CloseDB()
+
+	if err := driver.InsertCisco(func(yield func(models.Cisco, error) bool) {
+		yield(models.Cisco{
+			AdvisoryID: "cisco-sa-20190212-nae-dos",
+			CveID:      "CVE-2019-1688",
+			CVSSv3: []models.CiscoCVSS3{
+				{
+					Cvss3: models.Cvss3{
+						VectorString:          "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+						AttackVector:          "LOCAL",
+						AttackComplexity:      "LOW",
+						PrivilegesRequired:    "NONE",
+						UserInteraction:       "NONE",
+						Scope:                 "UNCHANGED",
+						ConfidentialityImpact: "HIGH",
+						IntegrityImpact:       "NONE",
+						AvailabilityImpact:    "HIGH",
+						BaseScore:             7.7,
+						BaseSeverity:          "HIGH",
+					},
+				},
+			},
+		}, nil)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	detail, err := driver.Get("CVE-2019-1688")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Ciscos) != 1 {
+		t.Fatalf("expected 1 Cisco advisory, got %d", len(detail.Ciscos))
+	}
+	if len(detail.Ciscos[0].CVSSv3) != 1 {
+		t.Fatalf("expected 1 Cisco CVSS v3 score, got %d", len(detail.Ciscos[0].CVSSv3))
+	}
+
+	got := detail.Ciscos[0].CVSSv3[0]
+	if got.VectorString != "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H" ||
+		got.AttackVector != "LOCAL" ||
+		got.AttackComplexity != "LOW" ||
+		got.PrivilegesRequired != "NONE" ||
+		got.UserInteraction != "NONE" ||
+		got.Scope != "UNCHANGED" ||
+		got.ConfidentialityImpact != "HIGH" ||
+		got.IntegrityImpact != "NONE" ||
+		got.AvailabilityImpact != "HIGH" ||
+		got.BaseScore != 7.7 ||
+		got.BaseSeverity != "HIGH" {
+		t.Fatalf("unexpected Cisco CVSS v3: %#v", got)
+	}
 }
 
 func TestMatch(t *testing.T) {

--- a/db/rdb.go
+++ b/db/rdb.go
@@ -248,6 +248,7 @@ func (r *RDBDriver) MigrateDB() error {
 		&models.Cisco{},
 		&models.CiscoBugID{},
 		&models.CiscoCweID{},
+		&models.CiscoCVSS3{},
 		&models.CiscoProduct{},
 		&models.CiscoReference{},
 	); err != nil {
@@ -478,6 +479,7 @@ func (r *RDBDriver) Get(cveID string) (*models.CveDetail, error) {
 		Where(&models.Cisco{CveID: cveID}).
 		Preload("BugIDs").
 		Preload("CweIDs").
+		Preload("CVSSv3").
 		Preload("Affected").
 		Preload("References").
 		Find(&detail.Ciscos).Error; err != nil {
@@ -1552,6 +1554,7 @@ func deleteCisco(tx *gorm.DB) error {
 		&models.Cisco{},
 		&models.CiscoBugID{},
 		&models.CiscoCweID{},
+		&models.CiscoCVSS3{},
 		&models.CiscoProduct{},
 		&models.CiscoReference{},
 	} {

--- a/fetcher/cisco/cisco.go
+++ b/fetcher/cisco/cisco.go
@@ -38,8 +38,22 @@ func FetchConvert() (iter.Seq2[models.Cisco, error], error) {
 		return nil, xerrors.Errorf("Failed to fetch cisco. err: %w", err)
 	}
 
+	cvrfDir, err := fetcher.FetchFromGHCR("vuls-data-raw-cisco-cvrf")
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, xerrors.Errorf("Failed to fetch cisco cvrf. err: %w", err)
+	}
+
+	cvss3s, err := collectCVSSv3(cvrfDir)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		_ = os.RemoveAll(cvrfDir)
+		return nil, xerrors.Errorf("Failed to collect cisco cvss v3. err: %w", err)
+	}
+
 	return func(yield func(models.Cisco, error) bool) {
 		defer os.RemoveAll(dir)
+		defer os.RemoveAll(cvrfDir)
 
 		yieldErr := fmt.Errorf("yield error")
 		if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
@@ -51,18 +65,12 @@ func FetchConvert() (iter.Seq2[models.Cisco, error], error) {
 				return nil
 			}
 
-			f, err := os.Open(path)
+			raw, err := readAdvisory(path)
 			if err != nil {
-				return xerrors.Errorf("Failed to open %s. err: %w", path, err)
-			}
-			defer f.Close()
-
-			var raw advisory
-			if err := json.NewDecoder(f).Decode(&raw); err != nil {
 				return xerrors.Errorf("Failed to decode %s. err: %w", path, err)
 			}
 
-			as, err := convert(raw)
+			as, err := convert(raw, cvss3s[raw.AdvisoryID])
 			if err != nil {
 				return xerrors.Errorf("Failed to convert %s. err: %w", path, err)
 			}
@@ -85,7 +93,96 @@ func FetchConvert() (iter.Seq2[models.Cisco, error], error) {
 	}, nil
 }
 
-func convert(raw advisory) (iter.Seq[models.Cisco], error) {
+func readAdvisory(path string) (advisory, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return advisory{}, xerrors.Errorf("Failed to open %s. err: %w", path, err)
+	}
+	defer f.Close()
+
+	var raw advisory
+	if err := json.NewDecoder(f).Decode(&raw); err != nil {
+		return advisory{}, err
+	}
+	return raw, nil
+}
+
+func collectCVSSv3(dir string) (map[string]map[string][]models.CiscoCVSS3, error) {
+	m := map[string]map[string][]models.CiscoCVSS3{}
+
+	if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		raw, err := readCVRF(path)
+		if err != nil {
+			return xerrors.Errorf("Failed to decode %s. err: %w", path, err)
+		}
+
+		if raw.DocumentTracking.Identification.ID == "" {
+			return nil
+		}
+
+		for _, v := range raw.Vulnerabilities {
+			if v.CVE == "" || v.CVE == "NA" || v.CVSSScoreSets == nil {
+				continue
+			}
+
+			for _, s := range v.CVSSScoreSets.ScoreSetV3 {
+				vector := ""
+				if s.VectorV3 != nil {
+					vector = *s.VectorV3
+				}
+				score := fetcher.StringToFloat(s.BaseScoreV3)
+				if score == 0 && vector == "" {
+					continue
+				}
+
+				cvss3 := parseCvss3VectorStr(vector)
+				cvss3.BaseScore = score
+				cvss3.BaseSeverity = cvss3Severity(score)
+
+				if _, ok := m[raw.DocumentTracking.Identification.ID]; !ok {
+					m[raw.DocumentTracking.Identification.ID] = map[string][]models.CiscoCVSS3{}
+				}
+				if !slices.ContainsFunc(m[raw.DocumentTracking.Identification.ID][v.CVE], func(c models.CiscoCVSS3) bool {
+					return c.VectorString == cvss3.VectorString && c.BaseScore == cvss3.BaseScore && c.BaseSeverity == cvss3.BaseSeverity
+				}) {
+					m[raw.DocumentTracking.Identification.ID][v.CVE] = append(m[raw.DocumentTracking.Identification.ID][v.CVE], models.CiscoCVSS3{
+						Cvss3: cvss3,
+					})
+				}
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, xerrors.Errorf("Failed to walk dir. err: %w", err)
+	}
+
+	return m, nil
+}
+
+func readCVRF(path string) (cvrf, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return cvrf{}, xerrors.Errorf("Failed to open %s. err: %w", path, err)
+	}
+	defer f.Close()
+
+	var raw cvrf
+	if err := json.NewDecoder(f).Decode(&raw); err != nil {
+		return cvrf{}, err
+	}
+	return raw, nil
+}
+
+func convert(raw advisory, cvss3s map[string][]models.CiscoCVSS3) (iter.Seq[models.Cisco], error) {
 	ps, err := func() ([]models.CiscoProduct, error) {
 		reqChan := make(chan string, len(raw.ProductNames))
 		resChan := make(chan *models.CiscoProduct, len(raw.ProductNames))
@@ -204,6 +301,7 @@ func convert(raw advisory) (iter.Seq[models.Cisco], error) {
 					}
 					return cs
 				}(),
+				CVSSv3:   cloneCVSSv3(cvss3s[cveid]),
 				Affected: slices.Clone(ps),
 				References: func() []models.CiscoReference {
 					rs := make([]models.CiscoReference, 0, 3)
@@ -243,6 +341,107 @@ func convert(raw advisory) (iter.Seq[models.Cisco], error) {
 			}
 		}
 	}, nil
+}
+
+func cloneCVSSv3(cvss3s []models.CiscoCVSS3) []models.CiscoCVSS3 {
+	if len(cvss3s) == 0 {
+		return nil
+	}
+	return slices.Clone(cvss3s)
+}
+
+func cvss3Severity(score float64) string {
+	switch {
+	case score == 0:
+		return "NONE"
+	case score < 4.0:
+		return "LOW"
+	case score < 7.0:
+		return "MEDIUM"
+	case score < 9.0:
+		return "HIGH"
+	default:
+		return "CRITICAL"
+	}
+}
+
+func parseCvss3VectorStr(vector string) models.Cvss3 {
+	cvss := models.Cvss3{VectorString: vector}
+	vector = strings.TrimPrefix(vector, "CVSS:3.1/")
+	vector = strings.TrimPrefix(vector, "CVSS:3.0/")
+	for _, s := range strings.Split(vector, "/") {
+		switch {
+		case strings.HasPrefix(s, "AV:"):
+			switch strings.TrimPrefix(s, "AV:") {
+			case "N":
+				cvss.AttackVector = "NETWORK"
+			case "A":
+				cvss.AttackVector = "ADJACENT_NETWORK"
+			case "L":
+				cvss.AttackVector = "LOCAL"
+			case "P":
+				cvss.AttackVector = "PHYSICAL"
+			}
+		case strings.HasPrefix(s, "AC:"):
+			switch strings.TrimPrefix(s, "AC:") {
+			case "L":
+				cvss.AttackComplexity = "LOW"
+			case "H":
+				cvss.AttackComplexity = "HIGH"
+			}
+		case strings.HasPrefix(s, "PR:"):
+			switch strings.TrimPrefix(s, "PR:") {
+			case "N":
+				cvss.PrivilegesRequired = "NONE"
+			case "L":
+				cvss.PrivilegesRequired = "LOW"
+			case "H":
+				cvss.PrivilegesRequired = "HIGH"
+			}
+		case strings.HasPrefix(s, "UI:"):
+			switch strings.TrimPrefix(s, "UI:") {
+			case "N":
+				cvss.UserInteraction = "NONE"
+			case "R":
+				cvss.UserInteraction = "REQUIRED"
+			}
+		case strings.HasPrefix(s, "S:"):
+			switch strings.TrimPrefix(s, "S:") {
+			case "U":
+				cvss.Scope = "UNCHANGED"
+			case "C":
+				cvss.Scope = "CHANGED"
+			}
+		case strings.HasPrefix(s, "C:"):
+			switch strings.TrimPrefix(s, "C:") {
+			case "N":
+				cvss.ConfidentialityImpact = "NONE"
+			case "L":
+				cvss.ConfidentialityImpact = "LOW"
+			case "H":
+				cvss.ConfidentialityImpact = "HIGH"
+			}
+		case strings.HasPrefix(s, "I:"):
+			switch strings.TrimPrefix(s, "I:") {
+			case "N":
+				cvss.IntegrityImpact = "NONE"
+			case "L":
+				cvss.IntegrityImpact = "LOW"
+			case "H":
+				cvss.IntegrityImpact = "HIGH"
+			}
+		case strings.HasPrefix(s, "A:"):
+			switch strings.TrimPrefix(s, "A:") {
+			case "N":
+				cvss.AvailabilityImpact = "NONE"
+			case "L":
+				cvss.AvailabilityImpact = "LOW"
+			case "H":
+				cvss.AvailabilityImpact = "HIGH"
+			}
+		}
+	}
+	return cvss
 }
 
 func convertAffectedProduct(name string) (*models.CiscoProduct, error) {

--- a/fetcher/cisco/cisco_test.go
+++ b/fetcher/cisco/cisco_test.go
@@ -1,7 +1,10 @@
 package cisco
 
 import (
+	"encoding/json"
 	"iter"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,9 +14,33 @@ import (
 	"github.com/vulsio/go-cve-dictionary/models"
 )
 
+func Test_advisoryUnmarshal(t *testing.T) {
+	var got advisory
+	if err := json.Unmarshal([]byte(`{
+  "advisoryId": "cisco-sa-20190212-nae-dos",
+  "csafUrl": "NA",
+  "cves": ["CVE-2019-1688"],
+  "cvrfUrl": "https://example.com/cvrf.xml",
+  "cvssBaseScore": "7.7",
+  "publicationUrl": "https://example.com/advisory"
+}`), &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.AdvisoryID != "cisco-sa-20190212-nae-dos" ||
+		got.CsafURL != "NA" ||
+		got.CvrfURL != "https://example.com/cvrf.xml" ||
+		got.CvssBaseScore != "7.7" ||
+		got.PublicationURL != "https://example.com/advisory" ||
+		!cmp.Equal(got.Cves, []string{"CVE-2019-1688"}) {
+		t.Fatalf("unexpected advisory: %#v", got)
+	}
+}
+
 func Test_convert(t *testing.T) {
 	type args struct {
-		raw advisory
+		raw    advisory
+		cvss3s map[string][]models.CiscoCVSS3
 	}
 	tests := []struct {
 		name    string
@@ -42,6 +69,7 @@ func Test_convert(t *testing.T) {
 					Summary:        "This document describes a vulnerability in Cisco's IOS software when\r\nthe 'established' keyword is used in extended IP access control lists. This bug\r\ncan, under very specific circumstances and only with certain IP host\r\nimplementations, allow unauthorized packets to circumvent a filtering router.\r\n&nbsp;\r\nThis advisory is posted at <a href=\"https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-19950601-key-packet-bypass\">https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-19950601-key-packet-bypass</a>.",
 					Version:        "1.0",
 				},
+				cvss3s: map[string][]models.CiscoCVSS3{},
 			},
 			want: func(yield func(models.Cisco) bool) {
 				if !yield(models.Cisco{
@@ -94,6 +122,42 @@ func Test_convert(t *testing.T) {
 					Summary:        "<p>Multiple vulnerabilities in the Simple Network Management Protocol (SNMP) subsystem of Cisco IOS Software, Cisco IOS XE Software, and Cisco IOS XR Software could allow an authenticated, remote attacker to cause a denial of service (DoS) condition on an affected device.</p>\r\n<p>For more information about these vulnerabilities, see the <a href=\"#details\">Details</a> section of this advisory.&nbsp;</p>\r\n<p>Cisco plans to release software updates that address these vulnerabilities. There are no workarounds that address these vulnerabilities. There are mitigations that address these vulnerabilities.</p>\r\n<p>This advisory is available at the following link:<br><a href=\"https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-snmp-dos-sdxnSUcW\">https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-snmp-dos-sdxnSUcW</a></p>",
 					Version:        "1.1",
 				},
+				cvss3s: map[string][]models.CiscoCVSS3{
+					"CVE-2025-20169": {
+						{
+							Cvss3: models.Cvss3{
+								VectorString:          "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
+								AttackVector:          "NETWORK",
+								AttackComplexity:      "LOW",
+								PrivilegesRequired:    "LOW",
+								UserInteraction:       "NONE",
+								Scope:                 "CHANGED",
+								ConfidentialityImpact: "NONE",
+								IntegrityImpact:       "NONE",
+								AvailabilityImpact:    "HIGH",
+								BaseScore:             7.7,
+								BaseSeverity:          "HIGH",
+							},
+						},
+					},
+					"CVE-2025-20170": {
+						{
+							Cvss3: models.Cvss3{
+								VectorString:          "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+								AttackVector:          "NETWORK",
+								AttackComplexity:      "LOW",
+								PrivilegesRequired:    "LOW",
+								UserInteraction:       "NONE",
+								Scope:                 "UNCHANGED",
+								ConfidentialityImpact: "NONE",
+								IntegrityImpact:       "NONE",
+								AvailabilityImpact:    "HIGH",
+								BaseScore:             6.5,
+								BaseSeverity:          "MEDIUM",
+							},
+						},
+					},
+				},
 			},
 			want: func(yield func(models.Cisco) bool) {
 				if !yield(models.Cisco{
@@ -108,6 +172,23 @@ func Test_convert(t *testing.T) {
 					},
 					CweIDs: []models.CiscoCweID{
 						{CweID: "CWE-805"},
+					},
+					CVSSv3: []models.CiscoCVSS3{
+						{
+							Cvss3: models.Cvss3{
+								VectorString:          "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:H",
+								AttackVector:          "NETWORK",
+								AttackComplexity:      "LOW",
+								PrivilegesRequired:    "LOW",
+								UserInteraction:       "NONE",
+								Scope:                 "CHANGED",
+								ConfidentialityImpact: "NONE",
+								IntegrityImpact:       "NONE",
+								AvailabilityImpact:    "HIGH",
+								BaseScore:             7.7,
+								BaseSeverity:          "HIGH",
+							},
+						},
 					},
 					Affected: []models.CiscoProduct{
 						{
@@ -187,6 +268,23 @@ func Test_convert(t *testing.T) {
 					CweIDs: []models.CiscoCweID{
 						{CweID: "CWE-805"},
 					},
+					CVSSv3: []models.CiscoCVSS3{
+						{
+							Cvss3: models.Cvss3{
+								VectorString:          "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+								AttackVector:          "NETWORK",
+								AttackComplexity:      "LOW",
+								PrivilegesRequired:    "LOW",
+								UserInteraction:       "NONE",
+								Scope:                 "UNCHANGED",
+								ConfidentialityImpact: "NONE",
+								IntegrityImpact:       "NONE",
+								AvailabilityImpact:    "HIGH",
+								BaseScore:             6.5,
+								BaseSeverity:          "MEDIUM",
+							},
+						},
+					},
 					Affected: []models.CiscoProduct{
 						{
 							CpeBase: models.CpeBase{
@@ -256,7 +354,7 @@ func Test_convert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convert(tt.args.raw)
+			got, err := convert(tt.args.raw, tt.args.cvss3s)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("convert() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -286,5 +384,64 @@ func Test_convert(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_collectCVSSv3(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "2019"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "2019", "cisco-sa-20190212-nae-dos.json"), []byte(`{
+  "document_tracking": {
+    "identification": {
+      "id": "cisco-sa-20190212-nae-dos"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2019-1688",
+      "cvss_score_sets": {
+        "score_set_v3": [
+          {
+            "base_score_v3": "7.7",
+            "vector_v3": "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+          }
+        ]
+      }
+    }
+  ]
+}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := collectCVSSv3(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]map[string][]models.CiscoCVSS3{
+		"cisco-sa-20190212-nae-dos": {
+			"CVE-2019-1688": {
+				{
+					Cvss3: models.Cvss3{
+						VectorString:          "CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+						AttackVector:          "LOCAL",
+						AttackComplexity:      "LOW",
+						PrivilegesRequired:    "NONE",
+						UserInteraction:       "NONE",
+						Scope:                 "UNCHANGED",
+						ConfidentialityImpact: "HIGH",
+						IntegrityImpact:       "NONE",
+						AvailabilityImpact:    "HIGH",
+						BaseScore:             7.7,
+						BaseSeverity:          "HIGH",
+					},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("collectCVSSv3(). (-expected +got):\n%s", diff)
 	}
 }

--- a/fetcher/cisco/types.go
+++ b/fetcher/cisco/types.go
@@ -19,3 +19,20 @@ type advisory struct {
 	Summary        string      `json:"summary"`
 	Version        string      `json:"version"`
 }
+
+type cvrf struct {
+	DocumentTracking struct {
+		Identification struct {
+			ID string `json:"id"`
+		} `json:"identification"`
+	} `json:"document_tracking"`
+	Vulnerabilities []struct {
+		CVE           string `json:"cve"`
+		CVSSScoreSets *struct {
+			ScoreSetV3 []struct {
+				BaseScoreV3 string  `json:"base_score_v3"`
+				VectorV3    *string `json:"vector_v3,omitempty"`
+			} `json:"score_set_v3,omitempty"`
+		} `json:"cvss_score_sets,omitempty"`
+	} `json:"vulnerabilities,omitempty"`
+}

--- a/models/cisco.go
+++ b/models/cisco.go
@@ -24,6 +24,7 @@ type Cisco struct {
 	CveID          string `gorm:"index:idx_ciscos_cveid;size:255"`
 	BugIDs         []CiscoBugID
 	CweIDs         []CiscoCweID
+	CVSSv3         []CiscoCVSS3
 	Affected       []CiscoProduct
 	References     []CiscoReference
 	FirstPublished time.Time
@@ -44,6 +45,13 @@ type CiscoCweID struct {
 	ID      int64  `json:"-"`
 	CiscoID uint   `json:"-" gorm:"index:idx_cisco_cwe_ids_cisco_id"`
 	CweID   string `gorm:"index:idx_cisco_cweid;size:255"`
+}
+
+// CiscoCVSS3 has Cisco CVSS v3 info
+type CiscoCVSS3 struct {
+	ID      int64 `json:"-"`
+	CiscoID uint  `json:"-" gorm:"index:idx_cisco_cvss3_cisco_id"`
+	Cvss3   `gorm:"embedded"`
 }
 
 // CiscoProduct :

--- a/models/models.go
+++ b/models/models.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LatestSchemaVersion manages the Schema version used in the latest go-cve-dictionary.
-const LatestSchemaVersion = 3
+const LatestSchemaVersion = 4
 
 // FetchMeta has meta information about fetched CVE data
 type FetchMeta struct {


### PR DESCRIPTION
 # What did you implement:

This PR fills a Cisco CVRF CVSSv3 gap in the existing Cisco datasource. The Cisco JSON advisory feed contains `cvssBaseScore`, but the CVSS vector and structured score set are available in the Cisco CVRF raw artifact. This change reads `vuls-data-raw-cisco-cvrf` alongside the existing Cisco JSON raw data and stores CVSS v3 metrics on each Cisco advisory/CVE entry.

Refs future-architect/vuls#777.

Changes:

- Add `models.CiscoCVSS3` and expose it as `Cisco.CVSSv3`
- Parse CVRF `BaseScoreV3` / `VectorV3` into embedded `models.Cvss3` fields
- Persist/preload/delete Cisco CVSSv3 records in RDB
- Bump schema version from 3 to 4 so existing DBs are refetched
- Keep Redis compatible through the existing whole-advisory JSON storage path
- Add regression coverage for `CVE-2019-1688` style CVRF CVSSv3 data

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Schema version is bumped because Cisco CVSSv3 adds a new RDB table.

# How Has This Been Tested?

```console
GOTOOLCHAIN=local CGO_ENABLED=0 GOPATH=/mnt/linux-dev/go GOCACHE=/mnt/linux-dev/go/cache GOMODCACHE=/mnt/linux-dev/go/pkg/mod /mnt/linux-dev/tools/go1.26.3/bin/go test ./fetcher/cisco ./models ./db
GOTOOLCHAIN=local CGO_ENABLED=0 GOPATH=/mnt/linux-dev/go GOCACHE=/mnt/linux-dev/go/cache GOMODCACHE=/mnt/linux-dev/go/pkg/mod /mnt/linux-dev/tools/go1.26.3/bin/go test ./...
```

I also verified locally against the current GHCR Cisco raw artifacts that `CVE-2019-1688` from `cisco-sa-20190212-nae-dos` yields base score `7.7` and vector `CVSS:3.0/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H`.

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `gofmt`
- [x] Pass the test commands above
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://github.com/future-architect/vuls/issues/777
